### PR TITLE
Use markdown for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,163 +228,178 @@ Modes allow different types of changes to attributes such as add values, append 
 Supported modes are `default` (no mode specified), `add`, `set`, `remove`.
 If no mode is specified, the default mode for the parameter is used.
 
-- Example for default mode: `summary="This is a summary."`.
-- Example for add mode: `summary:add=" Add this to the summary."`.
-- Example for set mode: `summary:set="Overwite the existing summary with this."`.
-- Example for remove mode: `custom.enumeration.list:remove=$,Unassigned`.
+- Example for `default` mode: `summary="This is a summary."`.
+- Example for `add` mode: `summary:add=" Add this to the summary."`.
+- Example for `set` mode: `summary:set="Overwite the existing summary with this."`.
+- Example for `remove` mode: `custom.enumeration.list:remove=$,Unassigned`.
 
-Which modes are supported and their behavior depends on attribute type. Single value attributes typically support default and set mode, but not add and remove mode. Multiple value attributes typically support default, add, set and remove mode. Default mode for single value attributes sets the value. Default mode for multiple value attributes adds the value(s). Set mode for multiple value attributes removes the old values and then adds the new value(s). Remove mode for multiple value attributes removes the old values specified, that can be found.
+Which modes are supported and their behavior depends on attribute type. Single value attributes typically support `default` and `set` mode, but not `add` and `remove` mode. Multiple value attributes typically support `default` , `add` , `set` and `remove` mode. `Default` mode for single value attributes sets the value. `Default` mode for multiple value attributes adds the value(s). `Set` mode for multiple value attributes removes the old values and then adds the new value(s). `Remove` mode for multiple value attributes removes the old values specified, that can be found.
 
-String values such as HTML, Summary, Wiki type attributes support default (same behavior as set mode), set and add mode.
+String values such as HTML, Summary, Wiki type attributes support `default` (same behavior as `set` mode), `set` and `add` mode.
 
 ### Special Properties
-	Work Item ID: Parameter "id" can not be changed.
-	Project Area: 
-	Parameter "projectArea" can only be specified when creating the work item. It can not be set to a different value later.
+**Work Item ID:** Parameter `"id"` can not be changed.
+
+**Project Area:** Parameter `"projectArea"` can only be specified when creating the work item. It can not be set to a different value later.
 
 ### Comments
-    Parameter "internalComments" can be used to add a comment.
-	This attribute only supports the default and add mode. Comments can not be removed.
-	Example: internalComments="This is a comment"
+Parameter `"internalComments"` can be used to add a comment. This attribute only supports the default and add mode. Comments can not be removed.
+
+Example: `internalComments="This is a comment"`
 
 ### Subscriptions 
-	Parameter "internalSubscriptions" can be used to subscribe a list of users using their user ID's.
-	This attribute supports the modes default (same as) add, set and remove mode.
-	Example set specific users: internalSubscriptions:set=al,tammy
-	Example add users: internalSubscriptions:add=deb,tanuj,bob
-	Example remove users: internalSubscriptions:remove=sally,bob
+Parameter `"internalSubscriptions"` can be used to subscribe a list of users using their user ID's. This attribute supports the modes default (same as) `add`, `set` and `remove` mode.
+
+- Example set specific users: `internalSubscriptions:set=al,tammy`
+- Example add users: `internalSubscriptions:add=deb,tanuj,bob`
+- Example remove users: `internalSubscriptions:remove=sally,bob`
 
 ### Tags
-    Parameter "internalTags" can be used to add a list of tags.
-	This attribute supports the modes default (same as) add, set and remove mode.
-	Example: internalTags=Tag1,..,TagN
+Parameter `"internalTags"` can be used to add a list of tags. This attribute supports the modes default (same as) `add`, `set` and `remove` mode.
 
-### Approvals:
-	Parameter "internalApprovals" can be used to add approvals and approvers using their user ID's.
-	Approvals only support the modes default (same as) add, set and remove. 
-	Set and remove only affects approvals of the same type. 
-Format is:
-	internalApprovals[<ID>][:<mode>]="approval:Approval Name as string:userID1,..,userIDn"
-	Where <ID> can be left out if only one approval is specified or needs to be unique if multiple approvals are specified. Where <mode> can be left out and defaults to add.
-	Available modes are:set add (set as default mode) and remove.
-	 Modes set and remove only remove approvals of the same type and must be enabled using the switch enableDeleteApprovals.
-	Example internalApprovals="review:Please Review:deb,tanuj"
-	Example internalApprovals="verification:Please verify:sally,al"
-	where the user list is optional and can contain one or more users ID's
+Example: `internalTags=Tag1,..,TagN`
 
-Work Item State: 
-	Parameter "internalState"  can be used to change the work item state.
-	State change only supports the modes default and set. 
-Format is: 
-	internalState=StateName to find a one step workflow action to change the state, and execute the action, or
-	internalState=forceState:StateName to force the state change to the target state even if no workflow action exists
+### Approvals
+Parameter `"internalApprovals"` can be used to add approvals and approvers using their user ID's. Approvals only support the modes `default` (same as) `add`, `set` and `remove`. Set and remove only affects approvals of the same type. 
 
-WorkFlow Action: 
-	A pseudo parameter "@workflowAction" can be used to set a workflow action to change the work item state when saving.
-	This attribute supports only the modes default and set. 
-	Example: @workflowAction="Stop working"
+#### Format
+    internalApprovals[<ID>][:<mode>]="approval:Approval Name as string:userID1,..,userIDn"
 
-Attachments: 
-	A pseudo parameter @attachFile can be used to upload attachments.
-	This attribute supports the modes default (same as) add, set and remove. 
-	Set removes all attachments, remove only removes attachments with the specified file path and description. 
-Format is: 
-	@attachFile[<IDString>]="SomeFilePath,Some Description,ContentTypeID,EncodingID"
+Where `<ID>` can be left out if only one approval is specified or needs to be unique if multiple approvals are specified. Where `<mode>` can be left out and defaults to `add`.
 
-	Where:
-		<IDString> must be unique for multiple attachments in one command. If only one attachment is uploaded, the IDString can be left empty.
-		ContentTypeID is text/plain or application/unknown or application/xml
-		EncodingID is UTF-8 or UTF-16LE or UTF-16BE or us-ascii.
+Available modes are: `set` `add` (set as default mode) and `remove`.
 
-	The file must be accessible and in the correct encoding.
+Modes `set` and `remove` only remove approvals of the same type and must be enabled using the switch `enableDeleteApprovals`.
 
-	Examples:
-		@attachFile="C:/temp/test.txt:Some Attachment:text/plain:UTF-8"
-		@attachFile_1="./test1.txt:Some Attachment 1:text/plain:UTF-8" @attachFile_2="./test2.txt:Some Attachment 2:text/plain:UTF-8"
+Example: `internalApprovals="review:Please Review:deb,tanuj"`
 
-Links: 
-	 A pseudo parameter @link_ can be used to link the current work item to other objects.
-	Links support the modes default (same as) add, set and remove. 
-	Set removes all links of the specified type before creating the new links. 
+Example: `internalApprovals="verification:Please verify:sally,al"`
 
-Work Item Links - links between this work item and another work item within the same repository:
-Format is:
-	@link_linktype=value
+where the user list is optional and can contain one or more users ID's
 
-	The parameter value is a list of one or more work items specified by their ID. The separator is:|
+### Work Item State:
+Parameter `"internalState"` can be used to change the work item state. State change only supports the modes `default` and `set`. 
 
-	@link_copied=id1|id2|...
-	@link_copied_from=id1|id2|...
-	@link_successor=id1|id2|...
-	@link_blocks=id1|id2|...
-	@link_resolves=id1|id2|...
-	@link_mentions=id1|id2|...
-	@link_predecessor=id1|id2|...
-	@link_parent=id1|id2|...
-	@link_duplicate_of=id1|id2|...
-	@link_duplicate=id1|id2|...
-	@link_related=id1|id2|...
-	@link_depends_on=id1|id2|...
-	@link_child=id1|id2|...
-	@link_resolved_by=id1|id2|...
+####Format
 
-	Example:
-		@link_related=123|80
+`internalState=StateName` to find a one step workflow action to change the state, and execute the action, or
+`internalState=forceState:StateName` to force the state change to the target state even if no workflow action exists
 
-CLM Work Item Links - CLM links between this work item and another work item within the same or acoross repositories
-Format is:
-	@link_linktype=value
+### WorkFlow Action 
+A pseudo parameter `"@workflowAction"` can be used to set a workflow action to change the work item state when saving. This attribute supports only the modes `default` and `set`. 
 
-	The parameter value is a list of one or more work items specified by their ID (if they are in the same repository) or by the Item URI. The separator is:|
+Example: `@workflowAction="Stop working"`
 
-	@link_affects_plan_item=id1|id2|URI2|...
-	@link_tracks_workitem=id1|id2|URI2|...
-	@link_related_change_management=id1|id2|URI2|...
-	@link_affected_by_defect=id1|id2|URI2|...
+### Attachments
+A pseudo parameter `@attachFile` can be used to upload attachments. This attribute supports the modes `default` (same as) `add`, `set` and `remove`. `Set` removes all attachments, `remove` only removes attachments with the specified file path and description. 
 
-	Example:
-		@link_tracks_workitem="https://clm.example.com:9443/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/80|120|150"
+#### Format
+    @attachFile[<IDString>]="SomeFilePath,Some Description,ContentTypeID,EncodingID"
 
-CLM URI Links - CLM links between this work item and another item, described by a valid URI, in a different repository
-Format is:
-	@link_linktype=value
+Where:
+`<IDString>` must be unique for multiple attachments in one command. If only one attachment is uploaded, the `IDString` can be left empty. `ContentTypeID` is `text/plain` or `application/unknown` or `application/xml`
 
-	The parameter value is a list of one or more CLM URI's for elements that support this link type. The separator is:|
+`EncodingID` is `UTF-8` or `UTF-16LE` or `UTF-16BE` or `us-ascii`.
 
-	@link_related_test_plan=uri1|uri2|...
-	@link_affects_requirement=uri1|uri2|...
-	@link_tested_by_test_case=uri1|uri2|...
-	@link_blocks_test_execution=uri1|uri2|...
-	@link_implements_requirement=uri1|uri2|...
-	@link_affects_execution_result=uri1|uri2|...
-	@link_related_artifact=uri1|uri2|...
-	@link_related_test_case=uri1|uri2|...
-	@link_tracks_requirement=uri1|uri2|...
-	@link_scm_tracks_scm_changes=uri1|uri2|...
-	@link_related_execution_record=uri1|uri2|...
+The file must be accessible and in the correct encoding.
 
-	Example:
-		@link_affects_requirement=https://clm.example.com:9443/rm/resources/_848a30e315524069854f55e1d35a402d|https://clm.example.com:9443/rm/resources/_6c96bedb0e9a490494273eefc6e1f7c5
+Examples:
 
-	Please note that the link "Associate Work Item" between a change set and the work item can only be created by the SCM component.
-	The link created here is the looser CLM link. Create the work item change set link using the SCM command line.
+    @attachFile="C:/temp/test.txt:Some Attachment:text/plain:UTF-8"
 
-Build result Links - Links from a work item to a build result in the same repository.
-Format is:
-	@link_reportAgainstBuild=buildResult1|buildResult2|...
+    @attachFile_1="./test1.txt:Some Attachment 1:text/plain:UTF-8" @attachFile_2="./test2.txt:Some Attachment 2:text/plain:UTF-8"
 
-	The parameter value is a list of one or more Buildresults specified by their ID or their label. Prefix the build labels @. The separator is:|
+### Links
+A pseudo parameter `@link_ can` be used to link the current work item to other objects. Links support the modes default (same as) `add`, `set` and `remove`. `Set` removes all links of the specified type before creating the new links. 
 
-	@link_reportAgainstBuild=id1|@BuildLabel2|...
-	@link_includedInBuild=id1|@BuildLabel2|...
+#### Work Item Links
+links between this work item and another work item within the same repository
+
+##### Format
+    @link_linktype=value
+
+The parameter value is a list of one or more work items specified by their ID. The separator is:`|`
+
+    @link_copied=id1|id2|...
+    @link_copied_from=id1|id2|...
+    @link_successor=id1|id2|...
+    @link_blocks=id1|id2|...
+    @link_resolves=id1|id2|...
+    @link_mentions=id1|id2|...
+    @link_predecessor=id1|id2|...
+    @link_parent=id1|id2|...
+    @link_duplicate_of=id1|id2|...
+    @link_duplicate=id1|id2|...
+    @link_related=id1|id2|...
+    @link_depends_on=id1|id2|...
+    @link_child=id1|id2|...
+    @link_resolved_by=id1|id2|...
+
+Example:
+
+    @link_related=123|80
+
+#### CLM Work Item Links 
+CLM links between this work item and another work item within the same or acoross repositories
+
+##### Format
+    @link_linktype=value
+
+The parameter value is a list of one or more work items specified by their ID (if they are in the same repository) or by the Item URI. The separator is:`|`
+
+    @link_affects_plan_item=id1|id2|URI2|...
+    @link_tracks_workitem=id1|id2|URI2|...
+    @link_related_change_management=id1|id2|URI2|...
+    @link_affected_by_defect=id1|id2|URI2|...
+
+Example:
+
+    @link_tracks_workitem="https://clm.example.com:9443/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/80|120|150"
+
+#### CLM URI Links 
+CLM links between this work item and another item, described by a valid URI, in a different repository
+
+##### Format
+    @link_linktype=value
+
+The parameter value is a list of one or more CLM URI's for elements that support this link type. The separator is:`|`
+
+    @link_related_test_plan=uri1|uri2|...
+    @link_affects_requirement=uri1|uri2|...
+    @link_tested_by_test_case=uri1|uri2|...
+    @link_blocks_test_execution=uri1|uri2|...
+    @link_implements_requirement=uri1|uri2|...
+    @link_affects_execution_result=uri1|uri2|...
+    @link_related_artifact=uri1|uri2|...
+    @link_related_test_case=uri1|uri2|...
+    @link_tracks_requirement=uri1|uri2|...
+    @link_scm_tracks_scm_changes=uri1|uri2|...
+    @link_related_execution_record=uri1|uri2|...
+
+Example:
+
+    @link_affects_requirement=https://clm.example.com:9443/rm/resources/_848a30e315524069854f55e1d35a402d|https://clm.example.com:9443/rm/resources/_6c96bedb0e9a490494273eefc6e1f7c5
+
+Please note that the link "Associate Work Item" between a change set and the work item can only be created by the SCM component. The link created here is the looser CLM link. Create the work item change set link using the SCM command line.
+
+#### Build result Links 
+Links from a work item to a build result in the same repository.
+
+##### Format
+    @link_reportAgainstBuild=buildResult1|buildResult2|...
+
+The parameter value is a list of one or more Buildresults specified by their ID or their label. Prefix the build labels @. The separator is:`|`
+
+    @link_reportAgainstBuild=id1|@BuildLabel2|...
+    @link_includedInBuild=id1|@BuildLabel2|...
 
 
-	Example:
+Example:
 
-		@link_reportAgainstBuild=@_IjluoH-oEeSHhcw_WFU6CQ|P20141208-1713
+    @link_reportAgainstBuild=@_IjluoH-oEeSHhcw_WFU6CQ|P20141208-1713
 
 
-### Aliases for attribute ID's
+##### Aliases for attribute ID's
 
 Available mappings:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# RTC Work Item Command Line
+WorkItemCommandLine Version V4.0
+
+**Note:**
+All of the following examples use bash multiline syntax for legibility. Leave them out when using single line commands, or replace them with a backtick (`) if you are using powershell.
+
+# Table of Contents
 -   [RTC Work Item Command Line](#rtc-work-item-command-line)
     -   [Usage](#usage)
     -   [Start in RMI server mode](#start-in-rmi-server-mode)
@@ -7,49 +14,31 @@
         -   [Values](#values)
         -   [Examples](#examples)
     -   [Modes](#modes)
-    -   [Special Properties](#special-properties)
-    -   [Comments](#comments)
-    -   [Subscriptions](#subscriptions)
-    -   [Tags](#tags)
-    -   [Approvals](#approvals)
-        -   [Format](#format)
-    -   [Work Item State:](#work-item-state)
-        -   [Format](#format-1)
-    -   [WorkFlow Action](#workflow-action)
-    -   [Attachments](#attachments)
-        -   [Format](#format-2)
-    -   [Links](#links)
-        -   [Work Item Links](#work-item-links)
-        -   [CLM Work Item Links](#clm-work-item-links)
-        -   [CLM URI Links](#clm-uri-links)
-        -   [Build result Links](#build-result-links)
-
-RTC Work Item Command Line
-==========================
-
-WorkItemCommandLine Version V4.0
-
-**Note:** All of the following examples use bash multiline syntax for
-legibility. Leave them out when using single line commands, or replace
-them with a backtick (\`) if you are using powershell.
-
-Usage
------
-
+        -   [Special Properties](#special-properties)
+        -   [Comments](#comments)
+        -   [Subscriptions](#subscriptions)
+        -   [Tags](#tags)
+        -   [Approvals](#approvals)
+        -   [Work Item State:](#work-item-state)
+        -   [WorkFlow Action](#workflow-action)
+        -   [Attachments](#attachments)
+        -   [Links](#links)
+ 
+## Usage 
 `-command {switch} {parameter[:mode]=value}`
 
-(See [A RTC WorkItem Command Line Version 2](http://wp.me/p2DlHq-s9) for
-a more complete description):
+(See [A RTC WorkItem Command Line Version 2](http://wp.me/p2DlHq-s9) for a more complete description):
 
-Multiple parameter/value pairs and switches can be provided separated by
-spaces. Commands might require specific parameters to be mandatory.
+Multiple parameter/value pairs and switches can be provided separated by spaces.
+Commands might require specific parameters to be mandatory.
 
-Switches influence the behavior of the operation. The switch
-/ignoreErrors ignores errors such as attributes or values not available.
+Switches influence the behavior of the operation.
+The switch /ignoreErrors ignores errors such as attributes or values not available.
+
 
 Available commands:
 
-``` {.bash}
+```bash
  -migrateattribute \
     targetAttributeID="value" \ 
     projectArea="value" \
@@ -61,7 +50,8 @@ Available commands:
     /ignoreErrors workItemType="value"  
 ```
 
-``` {.bash}
+
+```bash
 -update \
     /enableDeleteAttachment \
     /enableDeleteApprovals \
@@ -75,7 +65,7 @@ Available commands:
     {parameter[:mode]=value}
 ```
 
-``` {.bash}
+```bash
 -importworkitems \
     importFile="value" \
     /forcelinkcreation \
@@ -94,7 +84,7 @@ Available commands:
     [delimiter=","]
 ```
 
-``` {.bash}
+```bash
 -exportworkitems \
     exportFile="value" \
     projectArea="value" \
@@ -113,7 +103,7 @@ Available commands:
     [timestampFormat="TIMESTAMP_EXPORT_IMPORT_FORMAT_MMM_D_YYYY_HH_MM_A"]
 ```
 
-``` {.bash}
+```bash
 -create \
     /enableDeleteAttachment \
     /enableDeleteApprovals \
@@ -127,7 +117,7 @@ Available commands:
     {parameter[:mode]=value}
 ```
 
-``` {.bash}
+```bash
 -printtypeattributes \
     projectArea="value" \
     repository="value" \
@@ -136,33 +126,21 @@ Available commands:
     workItemType="value"  
 ```
 
-Start in RMI server mode
-------------------------
+## Start in RMI server mode
+Use the switch `/rmiServer` to start an instance as RMI server. In this mode, the process will not terminate, but wait for RMI requests to perform commands. It will service commands requested by other client instances that are started with the additional switch `/rmiClient`. It is not necessary to provide a command or any other input values, when starting the server as they will be ignored. Since the TeamPlatform needs to be initilized only once in this mode, the performance is considerably increased for multiple subsequent client calls.
 
-Use the switch `/rmiServer` to start an instance as RMI server. In this
-mode, the process will not terminate, but wait for RMI requests to
-perform commands. It will service commands requested by other client
-instances that are started with the additional switch `/rmiClient`. It
-is not necessary to provide a command or any other input values, when
-starting the server as they will be ignored. Since the TeamPlatform
-needs to be initilized only once in this mode, the performance is
-considerably increased for multiple subsequent client calls.
+By default, the RMI server uses the name `//localhost/RemoteWorkitemCommandLineServer` on port `1099`.
+It is possible to specify a different name and port by providing a value to the switch.
 
-By default, the RMI server uses the name
-`//localhost/RemoteWorkitemCommandLineServer` on port `1099`. It is
-possible to specify a different name and port by providing a value to
-the switch.
+The client command must be started with the same name and port as the server using the corresponding client switch
 
-The client command must be started with the same name and port as the
-server using the corresponding client switch
-
-Example server:
+Example server: 
 
 `/rmiServer=//clm.example.com:1199/WorkItemCommandLine`
 
-Example client:
+Example client: 
 
-``` {.bash}
+```bash
 -create \
     /rmiClient=//clm.example.com:1199/WorkItemCommandLine \
     repository=<repositoryURL> \
@@ -173,207 +151,143 @@ Example client:
     summary="New Item"
 ```
 
-Please note, that the server and the client require a policy file for
-the security manager. A Policy file `rmi_no.policy` is shipped with the
-download. Rename and modify the file to your requirements. To enable
-security Java requires to call the class with the additional vm argument
-`-Djava.security.policy=no.policy` where the policy file name must
-exist.
+Please note, that the server and the client require a policy file for the security manager. A Policy file `rmi_no.policy` is shipped with the download. Rename and modify the file to your requirements. To enable security Java requires to call the class with the additional vm argument `-Djava.security.policy=no.policy` where the policy file name must exist.
 
-WorkItem attribute parameter and value examples
------------------------------------------------
+## WorkItem attribute parameter and value examples
 
 Format for parameter is:
 
     parameter[:mode]=value
 
-No spaces are allowed between parameter, value and the `=`. Parameter
-and value can also not have spaces. Use `"` to enclose values with
-spaces. Example: `"A Space"`
+No spaces are allowed between parameter, value and the `=`. Parameter and value can also not have spaces. Use `"` to enclose values with spaces. Example: `"A Space"`
 
 ### Parameters
-
-Parameter is a work item attribute ID and value is a value or a list of
-values. Use the command `-printtypeattributes` to retrieve the available
-attribute ID's, or inspect the process configuration of your project
-area to extract the attribute ID's.
+Parameter is a work item attribute ID and value is a value or a list of values. Use the command `-printtypeattributes` to retrieve the available attribute ID's, or inspect the process configuration of your project area to extract the attribute ID's.
 
 ### Values
-
-The values are specified by a string. This is can be display name of
-that value (enumerations) or composed of display values of the path to
-this item (category, iterations, process areas). For other attributes,
-such as users, work item types or work items, use the ID.
+The values are specified by a string. This is can be display name of that value (enumerations) or composed of display values of the path to this item (category, iterations, process areas). For other attributes, such as users, work item types or work items, use the ID.
 
 ### Examples
+- For enumeration based attributes use the display value for the enumeration literal:
+    `internalPriority=High`
 
--   For enumeration based attributes use the display value for the
-    enumeration literal: `internalPriority=High`
-
--   For HTML and string based attributes use a string. HTML types like
-    summary, description, comment and HTML support the following syntax.
-
-    ``` {.html}
+- For HTML and string based attributes use a string. HTML types like summary, description, comment and HTML support the following syntax.
+    ```html
     description="Plain text<br/><b>bold text</b><br/><i>italic text</i><br/><a href="https://rsjazz.wordpress.com">External RSJazz Link</a><br/>User link to <b>@ralph </b><br/>Work Item link to Defect 3 <br/>"
     ```
 
--   For Wiki and multi line text attributes use `<br>` or `\n` for line
-    breaks and check the syntax in the wiki editor.
-
-    ``` {.html}
+- For Wiki and multi line text attributes use `<br>` or `\n` for line breaks and check the syntax in the wiki editor.
+    ```html
     custom.wiki="<br>=Heading1<br><br>Plain text\n==Heading 2\n\nNormal Text **bold text** <br>**bold text**<br>//Italics//"
     ```
 
--   For work item type, owner and some other attributes use the object
-    ID. `workItemType=task` `owner=tanuj`
+- For work item type, owner and some other attributes use the object ID.
+    `workItemType=task`
+    `owner=tanuj`
 
--   Use the display name for simple attributes or the path composed out
-    of the display names for hierarchical attributes.
+- Use the display name for simple attributes or the path composed out of the display names for hierarchical attributes.
 
-    `category=JKE/BRN` `foundIn="Sprint 2 Development"`
+    `category=JKE/BRN`
+    `foundIn="Sprint 2 Development"`
     `target="Main Development/Release 1.0/Sprint 3"`
     `custom.process.area="JKE Banking (Change Management)/Release Engineering"`
 
--   Dates have to be specified in the Java SimpleDateFormat notation.
+- Dates have to be specified in the Java SimpleDateFormat notation.
 
     `dueDate="2015/02/01 12:30:00 GMT+01:00"`
 
--   Duration values are specified in milliseconds, or a hours minutes
-    format.
+- Duration values are specified in milliseconds, or a hours minutes format.
 
     `duration=1800000 correctedEstimate=3600000 timeSpent=60000`
     `duration="1 hour" correctedEstimate="2 hours 30 minutes" timeSpent="30 minutes"`
 
--   WorkItem attribute values of <item type> List with a specified item
-    type such as userList. Format is using the separator `,`:
+- WorkItem attribute values of <item type> List with a specified item type such as userList. Format is using the separator `,`:
 
-    `"value1,value2,...,valueN"`
-    `Example: custom.user.list:add="deb,al,...,tanuj"`
+	`"value1,value2,...,valueN"`
+	`Example: custom.user.list:add="deb,al,...,tanuj"`
 
--   WorkItem attributes with an general attribute value such as Item or
-    itemList require encoding to locate the items. Format is:
-    `custom.item.list=value`
+- WorkItem attributes with an general attribute value such as Item or itemList require encoding to locate the items. Format is:
+	`custom.item.list=value`
 
-    Where value has the form: `<value>{,<value>}` With `<value>` of the
-    form `<TypeDescriptor>:<Item>`
+	Where value has the form: `<value>{,<value>}`
+	With `<value>` of the form `<TypeDescriptor>:<Item>`
 
-    No spaces are allowed in the value list.
+	No spaces are allowed in the value list.
 
-    Available <TypeDescriptor> values are:
+	Available <TypeDescriptor> values are:
 
-    -   Project area: ProjectArea - specified by its name.
+     - Project area: ProjectArea - specified by its name. 
 
         Example: `"ProjectArea:JKE Banking (Change Management)"`
-    -   Team area: TeamArea - specified by its name path.
+     - Team area: TeamArea - specified by its name path. 
 
-        Example:
-        `"TeamArea:JKE Banking (Change Management)/Release Engineering"`
-    -   Process area: ProcessArea - specified by its name path.
+        Example: `"TeamArea:JKE Banking (Change Management)/Release Engineering"`
+     - Process area: ProcessArea - specified by its name path. 
 
-        Example:
-        `"ProcessArea:JKE Banking (Change Management)/Business Recovery Matters"`
-    -   Category: Category - specified by its category path.
+        Example: `"ProcessArea:JKE Banking (Change Management)/Business Recovery Matters"`
+     - Category: Category - specified by its category path. 
 
         Example: `"Category:JKE/BRM"`
-    -   User: User - specified by its id.
+     - User: User - specified by its id. 
 
         Example: `"User:tanuj"`
-    -   Iteration: Iteration - specified by its name path (including the
-        development line name).
+     - Iteration: Iteration - specified by its name path (including the development line name). 
 
         Example: `"Iteration:Main Development/Release 1.0/Sprint 3"`
-    -   Work item: WorkItem - specified by its id.
+     - Work item: WorkItem - specified by its id. 
 
         Example: `"WorkItem:20"`
-    -   SCM component: SCMComponent - specified by its name.
+     - SCM component: SCMComponent - specified by its name. 
 
         Example: `"SCMComponent:Build"`
 
-Modes
------
+## Modes
+Modes allow different types of changes to attributes such as add values, append text or remove and set other data.
+Supported modes are `default` (no mode specified), `add`, `set`, `remove`.
+If no mode is specified, the default mode for the parameter is used.
 
-Modes allow different types of changes to attributes such as add values,
-append text or remove and set other data. Supported modes are `default`
-(no mode specified), `add`, `set`, `remove`. If no mode is specified,
-the default mode for the parameter is used.
+- Example for `default` mode: `summary="This is a summary."`.
+- Example for `add` mode: `summary:add=" Add this to the summary."`.
+- Example for `set` mode: `summary:set="Overwite the existing summary with this."`.
+- Example for `remove` mode: `custom.enumeration.list:remove=$,Unassigned`.
 
--   Example for `default` mode: `summary="This is a summary."`.
--   Example for `add` mode: `summary:add=" Add this to the summary."`.
--   Example for `set` mode:
-    `summary:set="Overwite the existing summary with this."`.
--   Example for `remove` mode:
-    `custom.enumeration.list:remove=$,Unassigned`.
+Which modes are supported and their behavior depends on attribute type. Single value attributes typically support `default` and `set` mode, but not `add` and `remove` mode. Multiple value attributes typically support `default` , `add` , `set` and `remove` mode. `Default` mode for single value attributes sets the value. `Default` mode for multiple value attributes adds the value(s). `Set` mode for multiple value attributes removes the old values and then adds the new value(s). `Remove` mode for multiple value attributes removes the old values specified, that can be found.
 
-Which modes are supported and their behavior depends on attribute type.
-Single value attributes typically support `default` and `set` mode, but
-not `add` and `remove` mode. Multiple value attributes typically support
-`default` , `add` , `set` and `remove` mode. `Default` mode for single
-value attributes sets the value. `Default` mode for multiple value
-attributes adds the value(s). `Set` mode for multiple value attributes
-removes the old values and then adds the new value(s). `Remove` mode for
-multiple value attributes removes the old values specified, that can be
-found.
+String values such as HTML, Summary, Wiki type attributes support `default` (same behavior as `set` mode), `set` and `add` mode.
 
-String values such as HTML, Summary, Wiki type attributes support
-`default` (same behavior as `set` mode), `set` and `add` mode.
-
-Special Properties
-------------------
-
+### Special Properties
 **Work Item ID:** Parameter `"id"` can not be changed.
 
-**Project Area:** Parameter `"projectArea"` can only be specified when
-creating the work item. It can not be set to a different value later.
+**Project Area:** Parameter `"projectArea"` can only be specified when creating the work item. It can not be set to a different value later.
 
-Comments
---------
-
-Parameter `"internalComments"` can be used to add a comment. This
-attribute only supports the default and add mode. Comments can not be
-removed.
+### Comments
+Parameter `"internalComments"` can be used to add a comment. This attribute only supports the default and add mode. Comments can not be removed.
 
 Example: `internalComments="This is a comment"`
 
-Subscriptions
--------------
+### Subscriptions 
+Parameter `"internalSubscriptions"` can be used to subscribe a list of users using their user ID's. This attribute supports the modes default (same as) `add`, `set` and `remove` mode.
 
-Parameter `"internalSubscriptions"` can be used to subscribe a list of
-users using their user ID's. This attribute supports the modes default
-(same as) `add`, `set` and `remove` mode.
+- Example set specific users: `internalSubscriptions:set=al,tammy`
+- Example add users: `internalSubscriptions:add=deb,tanuj,bob`
+- Example remove users: `internalSubscriptions:remove=sally,bob`
 
--   Example set specific users: `internalSubscriptions:set=al,tammy`
--   Example add users: `internalSubscriptions:add=deb,tanuj,bob`
--   Example remove users: `internalSubscriptions:remove=sally,bob`
-
-Tags
-----
-
-Parameter `"internalTags"` can be used to add a list of tags. This
-attribute supports the modes default (same as) `add`, `set` and `remove`
-mode.
+### Tags
+Parameter `"internalTags"` can be used to add a list of tags. This attribute supports the modes default (same as) `add`, `set` and `remove` mode.
 
 Example: `internalTags=Tag1,..,TagN`
 
-Approvals
----------
+### Approvals
+Parameter `"internalApprovals"` can be used to add approvals and approvers using their user ID's. Approvals only support the modes `default` (same as) `add`, `set` and `remove`. Set and remove only affects approvals of the same type. 
 
-Parameter `"internalApprovals"` can be used to add approvals and
-approvers using their user ID's. Approvals only support the modes
-`default` (same as) `add`, `set` and `remove`. Set and remove only
-affects approvals of the same type.
-
-### Format
-
+#### Format
     internalApprovals[<ID>][:<mode>]="approval:Approval Name as string:userID1,..,userIDn"
 
-Where `<ID>` can be left out if only one approval is specified or needs
-to be unique if multiple approvals are specified. Where `<mode>` can be
-left out and defaults to `add`.
+Where `<ID>` can be left out if only one approval is specified or needs to be unique if multiple approvals are specified. Where `<mode>` can be left out and defaults to `add`.
 
 Available modes are: `set` `add` (set as default mode) and `remove`.
 
-Modes `set` and `remove` only remove approvals of the same type and must
-be enabled using the switch `enableDeleteApprovals`.
+Modes `set` and `remove` only remove approvals of the same type and must be enabled using the switch `enableDeleteApprovals`.
 
 Example: `internalApprovals="review:Please Review:deb,tanuj"`
 
@@ -381,44 +295,27 @@ Example: `internalApprovals="verification:Please verify:sally,al"`
 
 where the user list is optional and can contain one or more users ID's
 
-Work Item State:
-----------------
+### Work Item State:
+Parameter `"internalState"` can be used to change the work item state. State change only supports the modes `default` and `set`. 
 
-Parameter `"internalState"` can be used to change the work item state.
-State change only supports the modes `default` and `set`.
+#### Format
 
-### Format
+`internalState=StateName` to find a one step workflow action to change the state, and execute the action, or
+`internalState=forceState:StateName` to force the state change to the target state even if no workflow action exists
 
-`internalState=StateName` to find a one step workflow action to change
-the state, and execute the action, or
-`internalState=forceState:StateName` to force the state change to the
-target state even if no workflow action exists
-
-WorkFlow Action
----------------
-
-A pseudo parameter `"@workflowAction"` can be used to set a workflow
-action to change the work item state when saving. This attribute
-supports only the modes `default` and `set`.
+### WorkFlow Action 
+A pseudo parameter `"@workflowAction"` can be used to set a workflow action to change the work item state when saving. This attribute supports only the modes `default` and `set`. 
 
 Example: `@workflowAction="Stop working"`
 
-Attachments
------------
+### Attachments
+A pseudo parameter `@attachFile` can be used to upload attachments. This attribute supports the modes `default` (same as) `add`, `set` and `remove`. `Set` removes all attachments, `remove` only removes attachments with the specified file path and description. 
 
-A pseudo parameter `@attachFile` can be used to upload attachments. This
-attribute supports the modes `default` (same as) `add`, `set` and
-`remove`. `Set` removes all attachments, `remove` only removes
-attachments with the specified file path and description.
-
-### Format
-
+#### Format
     @attachFile[<IDString>]="SomeFilePath,Some Description,ContentTypeID,EncodingID"
 
-Where: `<IDString>` must be unique for multiple attachments in one
-command. If only one attachment is uploaded, the `IDString` can be left
-empty. `ContentTypeID` is `text/plain` or `application/unknown` or
-`application/xml`
+Where:
+`<IDString>` must be unique for multiple attachments in one command. If only one attachment is uploaded, the `IDString` can be left empty. `ContentTypeID` is `text/plain` or `application/unknown` or `application/xml`
 
 `EncodingID` is `UTF-8` or `UTF-16LE` or `UTF-16BE` or `us-ascii`.
 
@@ -430,25 +327,16 @@ Examples:
 
     @attachFile_1="./test1.txt:Some Attachment 1:text/plain:UTF-8" @attachFile_2="./test2.txt:Some Attachment 2:text/plain:UTF-8"
 
-Links
------
+### Links
+A pseudo parameter `@link_ can` be used to link the current work item to other objects. Links support the modes default (same as) `add`, `set` and `remove`. `Set` removes all links of the specified type before creating the new links. 
 
-A pseudo parameter `@link_ can` be used to link the current work item to
-other objects. Links support the modes default (same as) `add`, `set`
-and `remove`. `Set` removes all links of the specified type before
-creating the new links.
+#### Work Item Links
+links between this work item and another work item within the same repository
 
-### Work Item Links
-
-links between this work item and another work item within the same
-repository
-
-#### Format
-
+##### Format
     @link_linktype=value
 
-The parameter value is a list of one or more work items specified by
-their ID. The separator is:`|`
+The parameter value is a list of one or more work items specified by their ID. The separator is:`|`
 
     @link_copied=id1|id2|...
     @link_copied_from=id1|id2|...
@@ -469,18 +357,13 @@ Example:
 
     @link_related=123|80
 
-### CLM Work Item Links
+#### CLM Work Item Links 
+CLM links between this work item and another work item within the same or acoross repositories
 
-CLM links between this work item and another work item within the same
-or acoross repositories
-
-#### Format
-
+##### Format
     @link_linktype=value
 
-The parameter value is a list of one or more work items specified by
-their ID (if they are in the same repository) or by the Item URI. The
-separator is:`|`
+The parameter value is a list of one or more work items specified by their ID (if they are in the same repository) or by the Item URI. The separator is:`|`
 
     @link_affects_plan_item=id1|id2|URI2|...
     @link_tracks_workitem=id1|id2|URI2|...
@@ -491,17 +374,13 @@ Example:
 
     @link_tracks_workitem="https://clm.example.com:9443/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/80|120|150"
 
-### CLM URI Links
+#### CLM URI Links 
+CLM links between this work item and another item, described by a valid URI, in a different repository
 
-CLM links between this work item and another item, described by a valid
-URI, in a different repository
-
-#### Format
-
+##### Format
     @link_linktype=value
 
-The parameter value is a list of one or more CLM URI's for elements that
-support this link type. The separator is:`|`
+The parameter value is a list of one or more CLM URI's for elements that support this link type. The separator is:`|`
 
     @link_related_test_plan=uri1|uri2|...
     @link_affects_requirement=uri1|uri2|...
@@ -519,30 +398,26 @@ Example:
 
     @link_affects_requirement=https://clm.example.com:9443/rm/resources/_848a30e315524069854f55e1d35a402d|https://clm.example.com:9443/rm/resources/_6c96bedb0e9a490494273eefc6e1f7c5
 
-Please note that the link "Associate Work Item" between a change set and
-the work item can only be created by the SCM component. The link created
-here is the looser CLM link. Create the work item change set link using
-the SCM command line.
+Please note that the link "Associate Work Item" between a change set and the work item can only be created by the SCM component. The link created here is the looser CLM link. Create the work item change set link using the SCM command line.
 
-### Build result Links
-
+#### Build result Links 
 Links from a work item to a build result in the same repository.
 
-#### Format
-
+##### Format
     @link_reportAgainstBuild=buildResult1|buildResult2|...
 
-The parameter value is a list of one or more Buildresults specified by
-their ID or their label. Prefix the build labels @. The separator is:`|`
+The parameter value is a list of one or more Buildresults specified by their ID or their label. Prefix the build labels @. The separator is:`|`
 
     @link_reportAgainstBuild=id1|@BuildLabel2|...
     @link_includedInBuild=id1|@BuildLabel2|...
+
 
 Example:
 
     @link_reportAgainstBuild=@_IjluoH-oEeSHhcw_WFU6CQ|P20141208-1713
 
-#### Aliases for attribute ID's
+
+##### Aliases for attribute ID's
 
 Available mappings:
 
@@ -595,3 +470,4 @@ Available mappings:
 | SEVERITY                                          | internalSeverity      |
 | CORRECTED_ESTIMATE                                | correctedEstimate     |
 | com.ibm.team.workitem.attribute.state             | internalState         |
+

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ where the user list is optional and can contain one or more users ID's
 ### Work Item State:
 Parameter `"internalState"` can be used to change the work item state. State change only supports the modes `default` and `set`. 
 
-####Format
+#### Format
 
 `internalState=StateName` to find a one step workflow action to change the state, and execute the action, or
 `internalState=forceState:StateName` to force the state change to the target state even if no workflow action exists

--- a/README.md
+++ b/README.md
@@ -546,52 +546,52 @@ Example:
 
 Available mappings:
 
-  From                                                To
-  --------------------------------------------------- --------------------
-  com.ibm.team.workitem.attribute.version             foundIn
-  SUMMARY                                             summary
-  RESOLVER                                            resolver
-  MODIFIED                                            modified
-  CREATOR                                             creator
-  MODIFIED\_BY                                        modifiedBy
-  CREATION\_DATE                                      creationDate
-  PLANNED\_FOR                                        target
-  com.ibm.team.workitem.attribute.severity            internalSeverity
-  com.ibm.team.workitem.attribute.category            category
-  com.ibm.team.workitem.attribute.duedate             dueDate
-  OWNER                                               owner
-  PROJECT\_AREA                                       projectArea
-  com.ibm.team.workitem.attribute.summary             summary
-  com.ibm.team.workitem.attribute.projectarea         projectArea
-  com.ibm.team.workitem.attribute.resolver            resolver
-  TAGS                                                internalTags
-  com.ibm.team.workitem.attribute.creator             creator
-  com.ibm.team.workitem.attribute.modified            modified
-  ID                                                  id
-  DESCRIPTION                                         description
-  TIME\_SPENT                                         timeSpent
-  com.ibm.team.workitem.attribute.correctedestimate   correctedEstimate
-  com.ibm.team.workitem.attribute.creationdate        creationDate
-  com.ibm.team.workitem.attribute.owner               owner
-  RESOLUTION\_DATE                                    resolutionDate
-  FOUND\_IN                                           foundIn
-  com.ibm.team.workitem.attribute.target              target
-  PRIORITY                                            internalPriority
-  com.ibm.team.workitem.attribute.duration            duration
-  ESTIMATE                                            duration
-  com.ibm.team.workitem.attribute.description         description
-  FILED\_AGAINST                                      category
-  com.ibm.team.workitem.attribute.tags                internalTags
-  com.ibm.team.workitem.attribute.resolutiondate      resolutionDate
-  RESOLUTION                                          internalResolution
-  com.ibm.team.workitem.attribute.id                  id
-  com.ibm.team.workitem.attribute.timespent           timeSpent
-  com.ibm.team.workitem.attribute.workitemtype        workItemType
-  STATE                                               internalState
-  com.ibm.team.workitem.attribute.modifiedby          modifiedBy
-  com.ibm.team.workitem.attribute.priority            internalPriority
-  DUE\_DATE                                           dueDate
-  TYPE                                                workItemType
-  SEVERITY                                            internalSeverity
-  CORRECTED\_ESTIMATE                                 correctedEstimate
-  com.ibm.team.workitem.attribute.state               internalState
+| From                                              | To                    |
+| ------------------------------------------------  | --------------------- |
+| com.ibm.team.workitem.attribute.version           | foundIn               |
+| SUMMARY                                           | summary               |
+| RESOLVER                                          | resolver              |
+| MODIFIED                                          | modified              |
+| CREATOR                                           | creator               |
+| MODIFIED_BY                                       | modifiedBy            |
+| CREATION_DATE                                     | creationDate          |
+| PLANNED_FOR                                       | target                |
+| com.ibm.team.workitem.attribute.severity          | internalSeverity      |
+| com.ibm.team.workitem.attribute.category          | category              |
+| com.ibm.team.workitem.attribute.duedate           | dueDate               |
+| OWNER                                             | owner                 |
+| PROJECT_AREA                                      | projectArea           |
+| com.ibm.team.workitem.attribute.summary           | summary               |
+| com.ibm.team.workitem.attribute.projectarea       | projectArea           |
+| com.ibm.team.workitem.attribute.resolver          | resolver              |
+| TAGS                                              | internalTags          |
+| com.ibm.team.workitem.attribute.creator           | creator               |
+| com.ibm.team.workitem.attribute.modified          | modified              |
+| ID                                                | id                    |
+| DESCRIPTION                                       | description           |
+| TIME_SPENT                                        | timeSpent             |
+| com.ibm.team.workitem.attribute.correctedestimate | correctedEstimate     |
+| com.ibm.team.workitem.attribute.creationdate      | creationDate          |
+| com.ibm.team.workitem.attribute.owner             | owner                 |
+| RESOLUTION_DATE                                   | resolutionDate        |
+| FOUND_IN                                          | foundIn               |
+| com.ibm.team.workitem.attribute.target            | target                |
+| PRIORITY                                          | internalPriority      |
+| com.ibm.team.workitem.attribute.duration          | duration              |
+| ESTIMATE                                          | duration              |
+| com.ibm.team.workitem.attribute.description       | description           |
+| FILED_AGAINST                                     | category              |
+| com.ibm.team.workitem.attribute.tags              | internalTags          |
+| com.ibm.team.workitem.attribute.resolutiondate    | resolutionDate        |
+| RESOLUTION                                        | internalResolution    |
+| com.ibm.team.workitem.attribute.id                | id                    |
+| com.ibm.team.workitem.attribute.timespent         | timeSpent             |
+| com.ibm.team.workitem.attribute.workitemtype      | workItemType          |
+| STATE                                             | internalState         |
+| com.ibm.team.workitem.attribute.modifiedby        | modifiedBy            |
+| com.ibm.team.workitem.attribute.priority          | internalPriority      |
+| DUE_DATE                                          | dueDate               |
+| TYPE                                              | workItemType          |
+| SEVERITY                                          | internalSeverity      |
+| CORRECTED_ESTIMATE                                | correctedEstimate     |
+| com.ibm.team.workitem.attribute.state             | internalState         |

--- a/README.md
+++ b/README.md
@@ -1,26 +1,55 @@
-# work-item-command-line
-## RTC Work Item Command Line
+-   [RTC Work Item Command Line](#rtc-work-item-command-line)
+    -   [Usage](#usage)
+    -   [Start in RMI server mode](#start-in-rmi-server-mode)
+    -   [WorkItem attribute parameter and value
+        examples](#workitem-attribute-parameter-and-value-examples)
+        -   [Parameters](#parameters)
+        -   [Values](#values)
+        -   [Examples](#examples)
+    -   [Modes](#modes)
+    -   [Special Properties](#special-properties)
+    -   [Comments](#comments)
+    -   [Subscriptions](#subscriptions)
+    -   [Tags](#tags)
+    -   [Approvals](#approvals)
+        -   [Format](#format)
+    -   [Work Item State:](#work-item-state)
+        -   [Format](#format-1)
+    -   [WorkFlow Action](#workflow-action)
+    -   [Attachments](#attachments)
+        -   [Format](#format-2)
+    -   [Links](#links)
+        -   [Work Item Links](#work-item-links)
+        -   [CLM Work Item Links](#clm-work-item-links)
+        -   [CLM URI Links](#clm-uri-links)
+        -   [Build result Links](#build-result-links)
 
-# WorkItemCommandLine Version V4.0
+RTC Work Item Command Line
+==========================
 
-**Note:**
-All of the following examples use bash multiline syntax for legibility. Leave them out when using single line commands, or replace them with a backtick (`) if you are using powershell.
+WorkItemCommandLine Version V4.0
 
-## Usage 
+**Note:** All of the following examples use bash multiline syntax for
+legibility. Leave them out when using single line commands, or replace
+them with a backtick (\`) if you are using powershell.
+
+Usage
+-----
+
 `-command {switch} {parameter[:mode]=value}`
 
-(See [A RTC WorkItem Command Line Version 2](http://wp.me/p2DlHq-s9) for a more complete description):
+(See [A RTC WorkItem Command Line Version 2](http://wp.me/p2DlHq-s9) for
+a more complete description):
 
-Multiple parameter/value pairs and switches can be provided separated by spaces.
-Commands might require specific parameters to be mandatory.
+Multiple parameter/value pairs and switches can be provided separated by
+spaces. Commands might require specific parameters to be mandatory.
 
-Switches influence the behavior of the operation.
-The switch /ignoreErrors ignores errors such as attributes or values not available.
-
+Switches influence the behavior of the operation. The switch
+/ignoreErrors ignores errors such as attributes or values not available.
 
 Available commands:
 
-```bash
+``` {.bash}
  -migrateattribute \
     targetAttributeID="value" \ 
     projectArea="value" \
@@ -32,8 +61,7 @@ Available commands:
     /ignoreErrors workItemType="value"  
 ```
 
-
-```bash
+``` {.bash}
 -update \
     /enableDeleteAttachment \
     /enableDeleteApprovals \
@@ -47,7 +75,7 @@ Available commands:
     {parameter[:mode]=value}
 ```
 
-```bash
+``` {.bash}
 -importworkitems \
     importFile="value" \
     /forcelinkcreation \
@@ -66,7 +94,7 @@ Available commands:
     [delimiter=","]
 ```
 
-```bash
+``` {.bash}
 -exportworkitems \
     exportFile="value" \
     projectArea="value" \
@@ -85,7 +113,7 @@ Available commands:
     [timestampFormat="TIMESTAMP_EXPORT_IMPORT_FORMAT_MMM_D_YYYY_HH_MM_A"]
 ```
 
-```bash
+``` {.bash}
 -create \
     /enableDeleteAttachment \
     /enableDeleteApprovals \
@@ -99,7 +127,7 @@ Available commands:
     {parameter[:mode]=value}
 ```
 
-```bash
+``` {.bash}
 -printtypeattributes \
     projectArea="value" \
     repository="value" \
@@ -108,21 +136,33 @@ Available commands:
     workItemType="value"  
 ```
 
-## Start in RMI server mode
-Use the switch `/rmiServer` to start an instance as RMI server. In this mode, the process will not terminate, but wait for RMI requests to perform commands. It will service commands requested by other client instances that are started with the additional switch `/rmiClient`. It is not necessary to provide a command or any other input values, when starting the server as they will be ignored. Since the TeamPlatform needs to be initilized only once in this mode, the performance is considerably increased for multiple subsequent client calls.
+Start in RMI server mode
+------------------------
 
-By default, the RMI server uses the name `//localhost/RemoteWorkitemCommandLineServer` on port `1099`.
-It is possible to specify a different name and port by providing a value to the switch.
+Use the switch `/rmiServer` to start an instance as RMI server. In this
+mode, the process will not terminate, but wait for RMI requests to
+perform commands. It will service commands requested by other client
+instances that are started with the additional switch `/rmiClient`. It
+is not necessary to provide a command or any other input values, when
+starting the server as they will be ignored. Since the TeamPlatform
+needs to be initilized only once in this mode, the performance is
+considerably increased for multiple subsequent client calls.
 
-The client command must be started with the same name and port as the server using the corresponding client switch
+By default, the RMI server uses the name
+`//localhost/RemoteWorkitemCommandLineServer` on port `1099`. It is
+possible to specify a different name and port by providing a value to
+the switch.
 
-Example server: 
+The client command must be started with the same name and port as the
+server using the corresponding client switch
+
+Example server:
 
 `/rmiServer=//clm.example.com:1199/WorkItemCommandLine`
 
-Example client: 
+Example client:
 
-```bash
+``` {.bash}
 -create \
     /rmiClient=//clm.example.com:1199/WorkItemCommandLine \
     repository=<repositoryURL> \
@@ -133,143 +173,207 @@ Example client:
     summary="New Item"
 ```
 
-Please note, that the server and the client require a policy file for the security manager. A Policy file `rmi_no.policy` is shipped with the download. Rename and modify the file to your requirements. To enable security Java requires to call the class with the additional vm argument `-Djava.security.policy=no.policy` where the policy file name must exist.
+Please note, that the server and the client require a policy file for
+the security manager. A Policy file `rmi_no.policy` is shipped with the
+download. Rename and modify the file to your requirements. To enable
+security Java requires to call the class with the additional vm argument
+`-Djava.security.policy=no.policy` where the policy file name must
+exist.
 
-## WorkItem attribute parameter and value examples
+WorkItem attribute parameter and value examples
+-----------------------------------------------
 
 Format for parameter is:
 
     parameter[:mode]=value
 
-No spaces are allowed between parameter, value and the `=`. Parameter and value can also not have spaces. Use `"` to enclose values with spaces. Example: `"A Space"`
+No spaces are allowed between parameter, value and the `=`. Parameter
+and value can also not have spaces. Use `"` to enclose values with
+spaces. Example: `"A Space"`
 
 ### Parameters
-Parameter is a work item attribute ID and value is a value or a list of values. Use the command `-printtypeattributes` to retrieve the available attribute ID's, or inspect the process configuration of your project area to extract the attribute ID's.
+
+Parameter is a work item attribute ID and value is a value or a list of
+values. Use the command `-printtypeattributes` to retrieve the available
+attribute ID's, or inspect the process configuration of your project
+area to extract the attribute ID's.
 
 ### Values
-The values are specified by a string. This is can be display name of that value (enumerations) or composed of display values of the path to this item (category, iterations, process areas). For other attributes, such as users, work item types or work items, use the ID.
+
+The values are specified by a string. This is can be display name of
+that value (enumerations) or composed of display values of the path to
+this item (category, iterations, process areas). For other attributes,
+such as users, work item types or work items, use the ID.
 
 ### Examples
-- For enumeration based attributes use the display value for the enumeration literal:
-    `internalPriority=High`
 
-- For HTML and string based attributes use a string. HTML types like summary, description, comment and HTML support the following syntax.
-    ```html
+-   For enumeration based attributes use the display value for the
+    enumeration literal: `internalPriority=High`
+
+-   For HTML and string based attributes use a string. HTML types like
+    summary, description, comment and HTML support the following syntax.
+
+    ``` {.html}
     description="Plain text<br/><b>bold text</b><br/><i>italic text</i><br/><a href="https://rsjazz.wordpress.com">External RSJazz Link</a><br/>User link to <b>@ralph </b><br/>Work Item link to Defect 3 <br/>"
     ```
 
-- For Wiki and multi line text attributes use `<br>` or `\n` for line breaks and check the syntax in the wiki editor.
-    ```html
+-   For Wiki and multi line text attributes use `<br>` or `\n` for line
+    breaks and check the syntax in the wiki editor.
+
+    ``` {.html}
     custom.wiki="<br>=Heading1<br><br>Plain text\n==Heading 2\n\nNormal Text **bold text** <br>**bold text**<br>//Italics//"
     ```
 
-- For work item type, owner and some other attributes use the object ID.
-    `workItemType=task`
-    `owner=tanuj`
+-   For work item type, owner and some other attributes use the object
+    ID. `workItemType=task` `owner=tanuj`
 
-- Use the display name for simple attributes or the path composed out of the display names for hierarchical attributes.
+-   Use the display name for simple attributes or the path composed out
+    of the display names for hierarchical attributes.
 
-    `category=JKE/BRN`
-    `foundIn="Sprint 2 Development"`
+    `category=JKE/BRN` `foundIn="Sprint 2 Development"`
     `target="Main Development/Release 1.0/Sprint 3"`
     `custom.process.area="JKE Banking (Change Management)/Release Engineering"`
 
-- Dates have to be specified in the Java SimpleDateFormat notation.
+-   Dates have to be specified in the Java SimpleDateFormat notation.
 
     `dueDate="2015/02/01 12:30:00 GMT+01:00"`
 
-- Duration values are specified in milliseconds, or a hours minutes format.
+-   Duration values are specified in milliseconds, or a hours minutes
+    format.
 
     `duration=1800000 correctedEstimate=3600000 timeSpent=60000`
     `duration="1 hour" correctedEstimate="2 hours 30 minutes" timeSpent="30 minutes"`
 
-- WorkItem attribute values of <item type> List with a specified item type such as userList. Format is using the separator `,`:
+-   WorkItem attribute values of <item type> List with a specified item
+    type such as userList. Format is using the separator `,`:
 
-	`"value1,value2,...,valueN"`
-	`Example: custom.user.list:add="deb,al,...,tanuj"`
+    `"value1,value2,...,valueN"`
+    `Example: custom.user.list:add="deb,al,...,tanuj"`
 
-- WorkItem attributes with an general attribute value such as Item or itemList require encoding to locate the items. Format is:
-	`custom.item.list=value`
+-   WorkItem attributes with an general attribute value such as Item or
+    itemList require encoding to locate the items. Format is:
+    `custom.item.list=value`
 
-	Where value has the form: `<value>{,<value>}`
-	With `<value>` of the form `<TypeDescriptor>:<Item>`
+    Where value has the form: `<value>{,<value>}` With `<value>` of the
+    form `<TypeDescriptor>:<Item>`
 
-	No spaces are allowed in the value list.
+    No spaces are allowed in the value list.
 
-	Available <TypeDescriptor> values are:
+    Available <TypeDescriptor> values are:
 
-     - Project area: ProjectArea - specified by its name. 
+    -   Project area: ProjectArea - specified by its name.
 
         Example: `"ProjectArea:JKE Banking (Change Management)"`
-     - Team area: TeamArea - specified by its name path. 
+    -   Team area: TeamArea - specified by its name path.
 
-        Example: `"TeamArea:JKE Banking (Change Management)/Release Engineering"`
-     - Process area: ProcessArea - specified by its name path. 
+        Example:
+        `"TeamArea:JKE Banking (Change Management)/Release Engineering"`
+    -   Process area: ProcessArea - specified by its name path.
 
-        Example: `"ProcessArea:JKE Banking (Change Management)/Business Recovery Matters"`
-     - Category: Category - specified by its category path. 
+        Example:
+        `"ProcessArea:JKE Banking (Change Management)/Business Recovery Matters"`
+    -   Category: Category - specified by its category path.
 
         Example: `"Category:JKE/BRM"`
-     - User: User - specified by its id. 
+    -   User: User - specified by its id.
 
         Example: `"User:tanuj"`
-     - Iteration: Iteration - specified by its name path (including the development line name). 
+    -   Iteration: Iteration - specified by its name path (including the
+        development line name).
 
         Example: `"Iteration:Main Development/Release 1.0/Sprint 3"`
-     - Work item: WorkItem - specified by its id. 
+    -   Work item: WorkItem - specified by its id.
 
         Example: `"WorkItem:20"`
-     - SCM component: SCMComponent - specified by its name. 
+    -   SCM component: SCMComponent - specified by its name.
 
         Example: `"SCMComponent:Build"`
 
-## Modes
-Modes allow different types of changes to attributes such as add values, append text or remove and set other data.
-Supported modes are `default` (no mode specified), `add`, `set`, `remove`.
-If no mode is specified, the default mode for the parameter is used.
+Modes
+-----
 
-- Example for `default` mode: `summary="This is a summary."`.
-- Example for `add` mode: `summary:add=" Add this to the summary."`.
-- Example for `set` mode: `summary:set="Overwite the existing summary with this."`.
-- Example for `remove` mode: `custom.enumeration.list:remove=$,Unassigned`.
+Modes allow different types of changes to attributes such as add values,
+append text or remove and set other data. Supported modes are `default`
+(no mode specified), `add`, `set`, `remove`. If no mode is specified,
+the default mode for the parameter is used.
 
-Which modes are supported and their behavior depends on attribute type. Single value attributes typically support `default` and `set` mode, but not `add` and `remove` mode. Multiple value attributes typically support `default` , `add` , `set` and `remove` mode. `Default` mode for single value attributes sets the value. `Default` mode for multiple value attributes adds the value(s). `Set` mode for multiple value attributes removes the old values and then adds the new value(s). `Remove` mode for multiple value attributes removes the old values specified, that can be found.
+-   Example for `default` mode: `summary="This is a summary."`.
+-   Example for `add` mode: `summary:add=" Add this to the summary."`.
+-   Example for `set` mode:
+    `summary:set="Overwite the existing summary with this."`.
+-   Example for `remove` mode:
+    `custom.enumeration.list:remove=$,Unassigned`.
 
-String values such as HTML, Summary, Wiki type attributes support `default` (same behavior as `set` mode), `set` and `add` mode.
+Which modes are supported and their behavior depends on attribute type.
+Single value attributes typically support `default` and `set` mode, but
+not `add` and `remove` mode. Multiple value attributes typically support
+`default` , `add` , `set` and `remove` mode. `Default` mode for single
+value attributes sets the value. `Default` mode for multiple value
+attributes adds the value(s). `Set` mode for multiple value attributes
+removes the old values and then adds the new value(s). `Remove` mode for
+multiple value attributes removes the old values specified, that can be
+found.
 
-### Special Properties
+String values such as HTML, Summary, Wiki type attributes support
+`default` (same behavior as `set` mode), `set` and `add` mode.
+
+Special Properties
+------------------
+
 **Work Item ID:** Parameter `"id"` can not be changed.
 
-**Project Area:** Parameter `"projectArea"` can only be specified when creating the work item. It can not be set to a different value later.
+**Project Area:** Parameter `"projectArea"` can only be specified when
+creating the work item. It can not be set to a different value later.
 
-### Comments
-Parameter `"internalComments"` can be used to add a comment. This attribute only supports the default and add mode. Comments can not be removed.
+Comments
+--------
+
+Parameter `"internalComments"` can be used to add a comment. This
+attribute only supports the default and add mode. Comments can not be
+removed.
 
 Example: `internalComments="This is a comment"`
 
-### Subscriptions 
-Parameter `"internalSubscriptions"` can be used to subscribe a list of users using their user ID's. This attribute supports the modes default (same as) `add`, `set` and `remove` mode.
+Subscriptions
+-------------
 
-- Example set specific users: `internalSubscriptions:set=al,tammy`
-- Example add users: `internalSubscriptions:add=deb,tanuj,bob`
-- Example remove users: `internalSubscriptions:remove=sally,bob`
+Parameter `"internalSubscriptions"` can be used to subscribe a list of
+users using their user ID's. This attribute supports the modes default
+(same as) `add`, `set` and `remove` mode.
 
-### Tags
-Parameter `"internalTags"` can be used to add a list of tags. This attribute supports the modes default (same as) `add`, `set` and `remove` mode.
+-   Example set specific users: `internalSubscriptions:set=al,tammy`
+-   Example add users: `internalSubscriptions:add=deb,tanuj,bob`
+-   Example remove users: `internalSubscriptions:remove=sally,bob`
+
+Tags
+----
+
+Parameter `"internalTags"` can be used to add a list of tags. This
+attribute supports the modes default (same as) `add`, `set` and `remove`
+mode.
 
 Example: `internalTags=Tag1,..,TagN`
 
-### Approvals
-Parameter `"internalApprovals"` can be used to add approvals and approvers using their user ID's. Approvals only support the modes `default` (same as) `add`, `set` and `remove`. Set and remove only affects approvals of the same type. 
+Approvals
+---------
 
-#### Format
+Parameter `"internalApprovals"` can be used to add approvals and
+approvers using their user ID's. Approvals only support the modes
+`default` (same as) `add`, `set` and `remove`. Set and remove only
+affects approvals of the same type.
+
+### Format
+
     internalApprovals[<ID>][:<mode>]="approval:Approval Name as string:userID1,..,userIDn"
 
-Where `<ID>` can be left out if only one approval is specified or needs to be unique if multiple approvals are specified. Where `<mode>` can be left out and defaults to `add`.
+Where `<ID>` can be left out if only one approval is specified or needs
+to be unique if multiple approvals are specified. Where `<mode>` can be
+left out and defaults to `add`.
 
 Available modes are: `set` `add` (set as default mode) and `remove`.
 
-Modes `set` and `remove` only remove approvals of the same type and must be enabled using the switch `enableDeleteApprovals`.
+Modes `set` and `remove` only remove approvals of the same type and must
+be enabled using the switch `enableDeleteApprovals`.
 
 Example: `internalApprovals="review:Please Review:deb,tanuj"`
 
@@ -277,27 +381,44 @@ Example: `internalApprovals="verification:Please verify:sally,al"`
 
 where the user list is optional and can contain one or more users ID's
 
-### Work Item State:
-Parameter `"internalState"` can be used to change the work item state. State change only supports the modes `default` and `set`. 
+Work Item State:
+----------------
 
-#### Format
+Parameter `"internalState"` can be used to change the work item state.
+State change only supports the modes `default` and `set`.
 
-`internalState=StateName` to find a one step workflow action to change the state, and execute the action, or
-`internalState=forceState:StateName` to force the state change to the target state even if no workflow action exists
+### Format
 
-### WorkFlow Action 
-A pseudo parameter `"@workflowAction"` can be used to set a workflow action to change the work item state when saving. This attribute supports only the modes `default` and `set`. 
+`internalState=StateName` to find a one step workflow action to change
+the state, and execute the action, or
+`internalState=forceState:StateName` to force the state change to the
+target state even if no workflow action exists
+
+WorkFlow Action
+---------------
+
+A pseudo parameter `"@workflowAction"` can be used to set a workflow
+action to change the work item state when saving. This attribute
+supports only the modes `default` and `set`.
 
 Example: `@workflowAction="Stop working"`
 
-### Attachments
-A pseudo parameter `@attachFile` can be used to upload attachments. This attribute supports the modes `default` (same as) `add`, `set` and `remove`. `Set` removes all attachments, `remove` only removes attachments with the specified file path and description. 
+Attachments
+-----------
 
-#### Format
+A pseudo parameter `@attachFile` can be used to upload attachments. This
+attribute supports the modes `default` (same as) `add`, `set` and
+`remove`. `Set` removes all attachments, `remove` only removes
+attachments with the specified file path and description.
+
+### Format
+
     @attachFile[<IDString>]="SomeFilePath,Some Description,ContentTypeID,EncodingID"
 
-Where:
-`<IDString>` must be unique for multiple attachments in one command. If only one attachment is uploaded, the `IDString` can be left empty. `ContentTypeID` is `text/plain` or `application/unknown` or `application/xml`
+Where: `<IDString>` must be unique for multiple attachments in one
+command. If only one attachment is uploaded, the `IDString` can be left
+empty. `ContentTypeID` is `text/plain` or `application/unknown` or
+`application/xml`
 
 `EncodingID` is `UTF-8` or `UTF-16LE` or `UTF-16BE` or `us-ascii`.
 
@@ -309,16 +430,25 @@ Examples:
 
     @attachFile_1="./test1.txt:Some Attachment 1:text/plain:UTF-8" @attachFile_2="./test2.txt:Some Attachment 2:text/plain:UTF-8"
 
-### Links
-A pseudo parameter `@link_ can` be used to link the current work item to other objects. Links support the modes default (same as) `add`, `set` and `remove`. `Set` removes all links of the specified type before creating the new links. 
+Links
+-----
 
-#### Work Item Links
-links between this work item and another work item within the same repository
+A pseudo parameter `@link_ can` be used to link the current work item to
+other objects. Links support the modes default (same as) `add`, `set`
+and `remove`. `Set` removes all links of the specified type before
+creating the new links.
 
-##### Format
+### Work Item Links
+
+links between this work item and another work item within the same
+repository
+
+#### Format
+
     @link_linktype=value
 
-The parameter value is a list of one or more work items specified by their ID. The separator is:`|`
+The parameter value is a list of one or more work items specified by
+their ID. The separator is:`|`
 
     @link_copied=id1|id2|...
     @link_copied_from=id1|id2|...
@@ -339,13 +469,18 @@ Example:
 
     @link_related=123|80
 
-#### CLM Work Item Links 
-CLM links between this work item and another work item within the same or acoross repositories
+### CLM Work Item Links
 
-##### Format
+CLM links between this work item and another work item within the same
+or acoross repositories
+
+#### Format
+
     @link_linktype=value
 
-The parameter value is a list of one or more work items specified by their ID (if they are in the same repository) or by the Item URI. The separator is:`|`
+The parameter value is a list of one or more work items specified by
+their ID (if they are in the same repository) or by the Item URI. The
+separator is:`|`
 
     @link_affects_plan_item=id1|id2|URI2|...
     @link_tracks_workitem=id1|id2|URI2|...
@@ -356,13 +491,17 @@ Example:
 
     @link_tracks_workitem="https://clm.example.com:9443/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/80|120|150"
 
-#### CLM URI Links 
-CLM links between this work item and another item, described by a valid URI, in a different repository
+### CLM URI Links
 
-##### Format
+CLM links between this work item and another item, described by a valid
+URI, in a different repository
+
+#### Format
+
     @link_linktype=value
 
-The parameter value is a list of one or more CLM URI's for elements that support this link type. The separator is:`|`
+The parameter value is a list of one or more CLM URI's for elements that
+support this link type. The separator is:`|`
 
     @link_related_test_plan=uri1|uri2|...
     @link_affects_requirement=uri1|uri2|...
@@ -380,76 +519,79 @@ Example:
 
     @link_affects_requirement=https://clm.example.com:9443/rm/resources/_848a30e315524069854f55e1d35a402d|https://clm.example.com:9443/rm/resources/_6c96bedb0e9a490494273eefc6e1f7c5
 
-Please note that the link "Associate Work Item" between a change set and the work item can only be created by the SCM component. The link created here is the looser CLM link. Create the work item change set link using the SCM command line.
+Please note that the link "Associate Work Item" between a change set and
+the work item can only be created by the SCM component. The link created
+here is the looser CLM link. Create the work item change set link using
+the SCM command line.
 
-#### Build result Links 
+### Build result Links
+
 Links from a work item to a build result in the same repository.
 
-##### Format
+#### Format
+
     @link_reportAgainstBuild=buildResult1|buildResult2|...
 
-The parameter value is a list of one or more Buildresults specified by their ID or their label. Prefix the build labels @. The separator is:`|`
+The parameter value is a list of one or more Buildresults specified by
+their ID or their label. Prefix the build labels @. The separator is:`|`
 
     @link_reportAgainstBuild=id1|@BuildLabel2|...
     @link_includedInBuild=id1|@BuildLabel2|...
-
 
 Example:
 
     @link_reportAgainstBuild=@_IjluoH-oEeSHhcw_WFU6CQ|P20141208-1713
 
-
-##### Aliases for attribute ID's
+#### Aliases for attribute ID's
 
 Available mappings:
 
-| From                                              | To                    |
-| ------------------------------------------------  | --------------------- |
-| com.ibm.team.workitem.attribute.version           | foundIn               |
-| SUMMARY                                           | summary               |
-| RESOLVER                                          | resolver              |
-| MODIFIED                                          | modified              |
-| CREATOR                                           | creator               |
-| MODIFIED_BY                                       | modifiedBy            |
-| CREATION_DATE                                     | creationDate          |
-| PLANNED_FOR                                       | target                |
-| com.ibm.team.workitem.attribute.severity          | internalSeverity      |
-| com.ibm.team.workitem.attribute.category          | category              |
-| com.ibm.team.workitem.attribute.duedate           | dueDate               |
-| OWNER                                             | owner                 |
-| PROJECT_AREA                                      | projectArea           |
-| com.ibm.team.workitem.attribute.summary           | summary               |
-| com.ibm.team.workitem.attribute.projectarea       | projectArea           |
-| com.ibm.team.workitem.attribute.resolver          | resolver              |
-| TAGS                                              | internalTags          |
-| com.ibm.team.workitem.attribute.creator           | creator               |
-| com.ibm.team.workitem.attribute.modified          | modified              |
-| ID                                                | id                    |
-| DESCRIPTION                                       | description           |
-| TIME_SPENT                                        | timeSpent             |
-| com.ibm.team.workitem.attribute.correctedestimate | correctedEstimate     |
-| com.ibm.team.workitem.attribute.creationdate      | creationDate          |
-| com.ibm.team.workitem.attribute.owner             | owner                 |
-| RESOLUTION_DATE                                   | resolutionDate        |
-| FOUND_IN                                          | foundIn               |
-| com.ibm.team.workitem.attribute.target            | target                |
-| PRIORITY                                          | internalPriority      |
-| com.ibm.team.workitem.attribute.duration          | duration              |
-| ESTIMATE                                          | duration              |
-| com.ibm.team.workitem.attribute.description       | description           |
-| FILED_AGAINST                                     | category              |
-| com.ibm.team.workitem.attribute.tags              | internalTags          |
-| com.ibm.team.workitem.attribute.resolutiondate    | resolutionDate        |
-| RESOLUTION                                        | internalResolution    |
-| com.ibm.team.workitem.attribute.id                | id                    |
-| com.ibm.team.workitem.attribute.timespent         | timeSpent             |
-| com.ibm.team.workitem.attribute.workitemtype      | workItemType          |
-| STATE                                             | internalState         |
-| com.ibm.team.workitem.attribute.modifiedby        | modifiedBy            |
-| com.ibm.team.workitem.attribute.priority          | internalPriority      |
-| DUE_DATE                                          | dueDate               |
-| TYPE                                              | workItemType          |
-| SEVERITY                                          | internalSeverity      |
-| CORRECTED_ESTIMATE                                | correctedEstimate     |
-| com.ibm.team.workitem.attribute.state             | internalState         |
-
+  From                                                To
+  --------------------------------------------------- --------------------
+  com.ibm.team.workitem.attribute.version             foundIn
+  SUMMARY                                             summary
+  RESOLVER                                            resolver
+  MODIFIED                                            modified
+  CREATOR                                             creator
+  MODIFIED\_BY                                        modifiedBy
+  CREATION\_DATE                                      creationDate
+  PLANNED\_FOR                                        target
+  com.ibm.team.workitem.attribute.severity            internalSeverity
+  com.ibm.team.workitem.attribute.category            category
+  com.ibm.team.workitem.attribute.duedate             dueDate
+  OWNER                                               owner
+  PROJECT\_AREA                                       projectArea
+  com.ibm.team.workitem.attribute.summary             summary
+  com.ibm.team.workitem.attribute.projectarea         projectArea
+  com.ibm.team.workitem.attribute.resolver            resolver
+  TAGS                                                internalTags
+  com.ibm.team.workitem.attribute.creator             creator
+  com.ibm.team.workitem.attribute.modified            modified
+  ID                                                  id
+  DESCRIPTION                                         description
+  TIME\_SPENT                                         timeSpent
+  com.ibm.team.workitem.attribute.correctedestimate   correctedEstimate
+  com.ibm.team.workitem.attribute.creationdate        creationDate
+  com.ibm.team.workitem.attribute.owner               owner
+  RESOLUTION\_DATE                                    resolutionDate
+  FOUND\_IN                                           foundIn
+  com.ibm.team.workitem.attribute.target              target
+  PRIORITY                                            internalPriority
+  com.ibm.team.workitem.attribute.duration            duration
+  ESTIMATE                                            duration
+  com.ibm.team.workitem.attribute.description         description
+  FILED\_AGAINST                                      category
+  com.ibm.team.workitem.attribute.tags                internalTags
+  com.ibm.team.workitem.attribute.resolutiondate      resolutionDate
+  RESOLUTION                                          internalResolution
+  com.ibm.team.workitem.attribute.id                  id
+  com.ibm.team.workitem.attribute.timespent           timeSpent
+  com.ibm.team.workitem.attribute.workitemtype        workItemType
+  STATE                                               internalState
+  com.ibm.team.workitem.attribute.modifiedby          modifiedBy
+  com.ibm.team.workitem.attribute.priority            internalPriority
+  DUE\_DATE                                           dueDate
+  TYPE                                                workItemType
+  SEVERITY                                            internalSeverity
+  CORRECTED\_ESTIMATE                                 correctedEstimate
+  com.ibm.team.workitem.attribute.state               internalState

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # work-item-command-line
-RTC Work Item Command Line
+## RTC Work Item Command Line
 
-WorkItemCommandLine Version V4.0
+# WorkItemCommandLine Version V4.0
 
-Usage (See http://wp.me/p2DlHq-s9 for a more complete description) :
--command {switch} {parameter[:mode]=value}
+**Note:**
+All of the following examples use bash multiline syntax for legibility. Leave them out when using single line commands, or replace them with a backtick (`) if you are using powershell.
+
+## Usage 
+`-command {switch} {parameter[:mode]=value}`
+
+(See [A RTC WorkItem Command Line Version 2](http://wp.me/p2DlHq-s9) for a more complete description):
 
 Multiple parameter/value pairs and switches can be provided separated by spaces.
 Commands might require specific parameters to be mandatory.
@@ -12,135 +17,249 @@ Commands might require specific parameters to be mandatory.
 Switches influence the behavior of the operation.
 The switch /ignoreErrors ignores errors such as attributes or values not available.
 
+
 Available commands:
--migrateattribute targetAttributeID="value" projectArea="value" /skipEmailNotification repository="value" password="value" user="value" sourceAttributeID="value" /ignoreErrors workItemType="value"  
--update /enableDeleteAttachment /enableDeleteApprovals /skipEmailNotification repository="value" /enforceSizeLimits id="value" password="value" user="value" /ignoreErrors  {parameter[:mode]=value}
--importworkitems importFile="value" /forcelinkcreation /importmultipass projectArea="value" /skipEmailNotification repository="value" /enforceSizeLimits password="value" user="value" /ignoreErrors /importdebug   [mappingFile="C:\temp\mapping.xml"] [encoding="UTF_16LE"][timestampFormat="TIMESTAMP_EXPORT_IMPORT_FORMAT_MMM_D_YYYY_HH_MM_A"] [delimiter=","]
--exportworkitems exportFile="value" projectArea="value" /asrtceclipse query="value" repository="value" /suppressAttributeExceptions /headerIDs password="value" user="value" /ignoreErrors   [encoding="UTF_16LE"] [delimiter=","] [columns="Type,Id,Planned For,Filed Against,Description,Found In"] [querysource="JKE Banking(Change Management),JKE Banking(Change Management)/Business Recovery Matters"][timestampFormat="TIMESTAMP_EXPORT_IMPORT_FORMAT_MMM_D_YYYY_HH_MM_A"]
--create /enableDeleteAttachment /enableDeleteApprovals projectArea="value" repository="value" /enforceSizeLimits password="value" user="value" /ignoreErrors workItemType="value"  {parameter[:mode]=value}
--printtypeattributes projectArea="value" repository="value" password="value" user="value" workItemType="value"  
 
-Start in RMI server mode:
-	Use the switch /rmiServer to start an instance as RMI server.
-	In this mode, the process will not terminate, but wait for RMI requests to perform commands. 
-	It will service commands requested by other client instances that are started with the 
-	additional switch /rmiClient .
-	It is not necessary to provide a command or any other input values, when starting the server 
-	as they will be ignored.
-	Since the TeamPlatform needs to be initilized only once in this mode, the performance
-	is considerably increased for multiple subsequent client calls.
-	By default, the RMI server uses the name //localhost/RemoteWorkitemCommandLineServer on port 1099.
-	It is possible to specify a different name and port by providing a value to the switch.
-	The client command must be started with the same name and port as the server using the corresponding client switch
-	Example server: /rmiServer=//clm.example.com:1199/WorkItemCommandLine
-	Example client: -create /rmiClient=//clm.example.com:1199/WorkItemCommandLine repository=<repositoryURL> user=<user> password=<pass> projectArea=<paName> workItemType=task summary="New Item"
-	Please note, that the server and the client require a policy file for the security manager.
-	A Policy file rmi_no.policy is shipped with the download. Rename and modify the file to your requirements
-	To enable security Java requires to call the class with the additional vm argument -Djava.security.policy=no.policy where the policy file name must exist.
+```bash
+ -migrateattribute \
+    targetAttributeID="value" \ 
+    projectArea="value" \
+    /skipEmailNotification \ 
+    repository="value" \ 
+    password="value" \ 
+    user="value" \
+    sourceAttributeID="value" \
+    /ignoreErrors workItemType="value"  
+```
 
-WorkItem attribute parameter and value examples:
+
+```bash
+-update \
+    /enableDeleteAttachment \
+    /enableDeleteApprovals \
+    /skipEmailNotification \
+    repository="value" \
+    /enforceSizeLimits \
+    id="value" \
+    password="value" \
+    user="value" \
+    /ignoreErrors \
+    {parameter[:mode]=value}
+```
+
+```bash
+-importworkitems \
+    importFile="value" \
+    /forcelinkcreation \
+    /importmultipass \
+    projectArea="value" \
+    /skipEmailNotification \
+    repository="value" \
+    /enforceSizeLimits \
+    password="value" \
+    user="value" \
+    /ignoreErrors \
+    /importdebug \
+    [mappingFile="C:\temp\mapping.xml"] \
+    [encoding="UTF_16LE"] \
+    [timestampFormat="TIMESTAMP_EXPORT_IMPORT_FORMAT_MMM_D_YYYY_HH_MM_A"] \
+    [delimiter=","]
+```
+
+```bash
+-exportworkitems \
+    exportFile="value" \
+    projectArea="value" \
+    /asrtceclipse \
+    query="value" \
+    repository="value" \
+    /suppressAttributeExceptions \
+    /headerIDs \
+    password="value" \
+    user="value" \
+    /ignoreErrors \
+    [encoding="UTF_16LE"] \
+    [delimiter=","] \
+    [columns="Type,Id,Planned For,Filed Against,Description,Found In"] \
+    [querysource="JKE Banking(Change Management),JKE Banking(Change Management)/Business Recovery Matters"] \
+    [timestampFormat="TIMESTAMP_EXPORT_IMPORT_FORMAT_MMM_D_YYYY_HH_MM_A"]
+```
+
+```bash
+-create \
+    /enableDeleteAttachment \
+    /enableDeleteApprovals \
+    projectArea="value" \
+    repository="value" \
+    /enforceSizeLimits \
+    password="value" \
+    user="value" \
+    /ignoreErrors \
+    workItemType="value" \
+    {parameter[:mode]=value}
+```
+
+```bash
+-printtypeattributes \
+    projectArea="value" \
+    repository="value" \
+    password="value" \
+    user="value" \
+    workItemType="value"  
+```
+
+## Start in RMI server mode
+Use the switch `/rmiServer` to start an instance as RMI server. In this mode, the process will not terminate, but wait for RMI requests to perform commands. It will service commands requested by other client instances that are started with the additional switch `/rmiClient`. It is not necessary to provide a command or any other input values, when starting the server as they will be ignored. Since the TeamPlatform needs to be initilized only once in this mode, the performance is considerably increased for multiple subsequent client calls.
+
+By default, the RMI server uses the name `//localhost/RemoteWorkitemCommandLineServer` on port `1099`.
+It is possible to specify a different name and port by providing a value to the switch.
+
+The client command must be started with the same name and port as the server using the corresponding client switch
+
+Example server: 
+
+`/rmiServer=//clm.example.com:1199/WorkItemCommandLine`
+
+Example client: 
+
+```bash
+-create \
+    /rmiClient=//clm.example.com:1199/WorkItemCommandLine \
+    repository=<repositoryURL> \
+    user=<user> \
+    password=<pass> \
+    projectArea=<paName> \
+    workItemType=task \
+    summary="New Item"
+```
+
+Please note, that the server and the client require a policy file for the security manager. A Policy file `rmi_no.policy` is shipped with the download. Rename and modify the file to your requirements. To enable security Java requires to call the class with the additional vm argument `-Djava.security.policy=no.policy` where the policy file name must exist.
+
+## WorkItem attribute parameter and value examples
 
 Format for parameter is:
-	parameter[:mode]=value
 
-No spaces are allowed between parameter, value and the =.
-Parameter and value can also not have spaces. Use " to enclose values with spaces. Example: "A Space"
+    parameter[:mode]=value
 
-Parameters:
-Parameter is a work item attribute ID and value is a value or a list of values.
-Use the command -printtypeattributes to retrieve the available attribute ID's, or
-inspect the process configuration of your project area to extract the attribute ID's.
+No spaces are allowed between parameter, value and the `=`. Parameter and value can also not have spaces. Use `"` to enclose values with spaces. Example: `"A Space"`
 
-Values:
-The values are specified by a string. This is can be display name of that value (enumerations)
-or composed of display values of the path to this item (category, iterations, process areas).
-For other attributes, such as users, work item types or work items, use the ID.
+### Parameters
+Parameter is a work item attribute ID and value is a value or a list of values. Use the command `-printtypeattributes` to retrieve the available attribute ID's, or inspect the process configuration of your project area to extract the attribute ID's.
 
-	Examples
-	- For enumeration based attributes use the display value for the enumeration literal:
-		internalPriority=High
-	- For HTML and string based attributes use a string.
-	  HTML types like summary, description, comment and HTML support the syntax below.
-		description="Plain text<br/><b>bold text</b><br/><i>italic text</i><br/><a href="https://rsjazz.wordpress.com">External RSJazz Link</a><br/>User link to <b>@ralph </b><br/>Work Item link to Defect 3 <br/>"
-	- For Wiki and multi line text attributes use <br> or \n for line breaks and check the syntax in the wiki editor.
-		custom.wiki="<br>=Heading1<br><br>Plain text\n==Heading 2\n\nNormal Text **bold text** <br>**bold text**<br>//Italics//"
-	- For work item type, owner and some other attributes use the object ID.
-		workItemType=task
-		owner=tanuj
-	- Use the display name for simple attributes or the path composed out of the display names for hierarchical attributes.
-		category=JKE/BRN
-		foundIn="Sprint 2 Development"
-		target="Main Development/Release 1.0/Sprint 3"
-		custom.process.area="JKE Banking (Change Management)/Release Engineering"
-	- Dates have to be specified in the Java SimpleDateFormat notation.
-		dueDate="2015/02/01 12:30:00 GMT+01:00"
-	- Duration values are specified in milliseconds, or a hours minutes format.
-		duration=1800000 correctedEstimate=3600000 timeSpent=60000
-		duration="1 hour" correctedEstimate="2 hours 30 minutes" timeSpent="30 minutes"
+### Values
+The values are specified by a string. This is can be display name of that value (enumerations) or composed of display values of the path to this item (category, iterations, process areas). For other attributes, such as users, work item types or work items, use the ID.
 
-WorkItem attribute values of <item type>List with a specified item type such as userList.
-Format is using the separator , :
-	"value1,value2,...,valueN"
-	Example: custom.user.list:add="deb,al,...,tanuj"
+### Examples
+- For enumeration based attributes use the display value for the enumeration literal:
+    `internalPriority=High`
 
-WorkItem attributes with an general attribute value such as Item or itemList require encoding to locate the items.
-Format is:
-	custom.item.list=value
+- For HTML and string based attributes use a string. HTML types like summary, description, comment and HTML support the following syntax.
+    ```html
+    description="Plain text<br/><b>bold text</b><br/><i>italic text</i><br/><a href="https://rsjazz.wordpress.com">External RSJazz Link</a><br/>User link to <b>@ralph </b><br/>Work Item link to Defect 3 <br/>"
+    ```
 
-	Where value has the form: <value>{,<value>}
-	With <value> of the form <TypeDescriptor>:<Item>.
+- For Wiki and multi line text attributes use `<br>` or `\n` for line breaks and check the syntax in the wiki editor.
+    ```html
+    custom.wiki="<br>=Heading1<br><br>Plain text\n==Heading 2\n\nNormal Text **bold text** <br>**bold text**<br>//Italics//"
+    ```
+
+- For work item type, owner and some other attributes use the object ID.
+    `workItemType=task`
+    `owner=tanuj`
+
+- Use the display name for simple attributes or the path composed out of the display names for hierarchical attributes.
+
+    `category=JKE/BRN`
+    `foundIn="Sprint 2 Development"`
+    `target="Main Development/Release 1.0/Sprint 3"`
+    `custom.process.area="JKE Banking (Change Management)/Release Engineering"`
+
+- Dates have to be specified in the Java SimpleDateFormat notation.
+
+    `dueDate="2015/02/01 12:30:00 GMT+01:00"`
+
+- Duration values are specified in milliseconds, or a hours minutes format.
+
+    `duration=1800000 correctedEstimate=3600000 timeSpent=60000`
+    `duration="1 hour" correctedEstimate="2 hours 30 minutes" timeSpent="30 minutes"`
+
+- WorkItem attribute values of <item type> List with a specified item type such as userList. Format is using the separator `,`:
+
+	`"value1,value2,...,valueN"`
+	`Example: custom.user.list:add="deb,al,...,tanuj"`
+
+- WorkItem attributes with an general attribute value such as Item or itemList require encoding to locate the items. Format is:
+	`custom.item.list=value`
+
+	Where value has the form: `<value>{,<value>}`
+	With `<value>` of the form `<TypeDescriptor>:<Item>`
 
 	No spaces are allowed in the value list.
 
 	Available <TypeDescriptor> values are:
-		 Project area: ProjectArea - specified by its name. Example: "ProjectArea:JKE Banking (Change Management)"
-		 Team area: TeamArea - specified by its name path. Example: "TeamArea:JKE Banking (Change Management)/Release Engineering"
-		 Process area: ProcessArea - specified by its name path. Example: "ProcessArea:JKE Banking (Change Management)/Business Recovery Matters"
-		 Category: Category - specified by its category path. Example: "Category:JKE/BRM"
-		 User: User - specified by its id. Example: "User:tanuj
-		 Iteration: Iteration - specified by its name path (including the development line name). Example: "Iteration:Main Development/Release 1.0/Sprint 3"
-		 Work item: WorkItem - specified by its id. Example: "WorkItem:20"
-		 SCM component: SCMComponent - specified by its name. Example: "SCMComponent:Build"
 
-Modes:
+     - Project area: ProjectArea - specified by its name. 
+
+        Example: `"ProjectArea:JKE Banking (Change Management)"`
+     - Team area: TeamArea - specified by its name path. 
+
+        Example: `"TeamArea:JKE Banking (Change Management)/Release Engineering"`
+     - Process area: ProcessArea - specified by its name path. 
+
+        Example: `"ProcessArea:JKE Banking (Change Management)/Business Recovery Matters"`
+     - Category: Category - specified by its category path. 
+
+        Example: `"Category:JKE/BRM"`
+     - User: User - specified by its id. 
+
+        Example: `"User:tanuj"`
+     - Iteration: Iteration - specified by its name path (including the development line name). 
+
+        Example: `"Iteration:Main Development/Release 1.0/Sprint 3"`
+     - Work item: WorkItem - specified by its id. 
+
+        Example: `"WorkItem:20"`
+     - SCM component: SCMComponent - specified by its name. 
+
+        Example: `"SCMComponent:Build"`
+
+## Modes
 Modes allow different types of changes to attributes such as add values, append text or remove and set other data.
-Supported modes are default (no mode specified), add, set, remove.
+Supported modes are `default` (no mode specified), `add`, `set`, `remove`.
 If no mode is specified, the default mode for the parameter is used.
-	Example for default mode: summary="This is a summary.".
-	Example for add mode: summary:add=" Add this to the summary.".
-	Example for set mode: summary:set="Overwite the existing summary with this.".
-	Example for remove mode: custom.enumeration.list:remove=$,Unassigned.
 
-Which modes are supported and their behavior depends on attribute type.
-Single value attributes typically support default and set mode, but not add and remove mode. 
-Multiple value attributes typically support default, add, set and remove mode.
-Default mode for single value attributes sets the value.
-Default mode for multiple value attributes adds the value(s).
-Set mode for multiple value attributes removes the old values and then adds the new value(s).
-Remove mode for multiple value attributes removes the old values specified, that can be found.
+- Example for default mode: `summary="This is a summary."`.
+- Example for add mode: `summary:add=" Add this to the summary."`.
+- Example for set mode: `summary:set="Overwite the existing summary with this."`.
+- Example for remove mode: `custom.enumeration.list:remove=$,Unassigned`.
+
+Which modes are supported and their behavior depends on attribute type. Single value attributes typically support default and set mode, but not add and remove mode. Multiple value attributes typically support default, add, set and remove mode. Default mode for single value attributes sets the value. Default mode for multiple value attributes adds the value(s). Set mode for multiple value attributes removes the old values and then adds the new value(s). Remove mode for multiple value attributes removes the old values specified, that can be found.
+
 String values such as HTML, Summary, Wiki type attributes support default (same behavior as set mode), set and add mode.
 
-Special Properties:
+### Special Properties
 	Work Item ID: Parameter "id" can not be changed.
 	Project Area: 
 	Parameter "projectArea" can only be specified when creating the work item. It can not be set to a different value later.
 
-Comments: Parameter "internalComments" can be used to add a comment.
+### Comments
+    Parameter "internalComments" can be used to add a comment.
 	This attribute only supports the default and add mode. Comments can not be removed.
 	Example: internalComments="This is a comment"
 
-Subscriptions: 
+### Subscriptions 
 	Parameter "internalSubscriptions" can be used to subscribe a list of users using their user ID's.
 	This attribute supports the modes default (same as) add, set and remove mode.
 	Example set specific users: internalSubscriptions:set=al,tammy
 	Example add users: internalSubscriptions:add=deb,tanuj,bob
 	Example remove users: internalSubscriptions:remove=sally,bob
 
-Tags: Parameter "internalTags" can be used to add a list of tags.
+### Tags
+    Parameter "internalTags" can be used to add a list of tags.
 	This attribute supports the modes default (same as) add, set and remove mode.
 	Example: internalTags=Tag1,..,TagN
 
-Approvals: 
+### Approvals:
 	Parameter "internalApprovals" can be used to add approvals and approvers using their user ID's.
 	Approvals only support the modes default (same as) add, set and remove. 
 	Set and remove only affects approvals of the same type. 
@@ -265,54 +384,57 @@ Format is:
 		@link_reportAgainstBuild=@_IjluoH-oEeSHhcw_WFU6CQ|P20141208-1713
 
 
-Aliases for attribute ID's:
+### Aliases for attribute ID's
+
 Available mappings:
 
-	com.ibm.team.workitem.attribute.version: foundIn
-	SUMMARY: summary
-	RESOLVER: resolver
-	MODIFIED: modified
-	CREATOR: creator
-	MODIFIED_BY: modifiedBy
-	CREATION_DATE: creationDate
-	PLANNED_FOR: target
-	com.ibm.team.workitem.attribute.severity: internalSeverity
-	com.ibm.team.workitem.attribute.category: category
-	com.ibm.team.workitem.attribute.duedate: dueDate
-	OWNER: owner
-	PROJECT_AREA: projectArea
-	com.ibm.team.workitem.attribute.summary: summary
-	com.ibm.team.workitem.attribute.projectarea: projectArea
-	com.ibm.team.workitem.attribute.resolver: resolver
-	TAGS: internalTags
-	com.ibm.team.workitem.attribute.creator: creator
-	com.ibm.team.workitem.attribute.modified: modified
-	ID: id
-	DESCRIPTION: description
-	TIME_SPENT: timeSpent
-	com.ibm.team.workitem.attribute.correctedestimate: correctedEstimate
-	com.ibm.team.workitem.attribute.creationdate: creationDate
-	com.ibm.team.workitem.attribute.owner: owner
-	RESOLUTION_DATE: resolutionDate
-	FOUND_IN: foundIn
-	com.ibm.team.workitem.attribute.target: target
-	PRIORITY: internalPriority
-	com.ibm.team.workitem.attribute.duration: duration
-	ESTIMATE: duration
-	com.ibm.team.workitem.attribute.description: description
-	FILED_AGAINST: category
-	com.ibm.team.workitem.attribute.tags: internalTags
-	com.ibm.team.workitem.attribute.resolutiondate: resolutionDate
-	RESOLUTION: internalResolution
-	com.ibm.team.workitem.attribute.id: id
-	com.ibm.team.workitem.attribute.timespent: timeSpent
-	com.ibm.team.workitem.attribute.workitemtype: workItemType
-	STATE: internalState
-	com.ibm.team.workitem.attribute.modifiedby: modifiedBy
-	com.ibm.team.workitem.attribute.priority: internalPriority
-	DUE_DATE: dueDate
-	TYPE: workItemType
-	SEVERITY: internalSeverity
-	CORRECTED_ESTIMATE: correctedEstimate
-	com.ibm.team.workitem.attribute.state: internalState
+| From                                              | To                    |
+| ------------------------------------------------  | --------------------- |
+| com.ibm.team.workitem.attribute.version           | foundIn               |
+| SUMMARY                                           | summary               |
+| RESOLVER                                          | resolver              |
+| MODIFIED                                          | modified              |
+| CREATOR                                           | creator               |
+| MODIFIED_BY                                       | modifiedBy            |
+| CREATION_DATE                                     | creationDate          |
+| PLANNED_FOR                                       | target                |
+| com.ibm.team.workitem.attribute.severity          | internalSeverity      |
+| com.ibm.team.workitem.attribute.category          | category              |
+| com.ibm.team.workitem.attribute.duedate           | dueDate               |
+| OWNER                                             | owner                 |
+| PROJECT_AREA                                      | projectArea           |
+| com.ibm.team.workitem.attribute.summary           | summary               |
+| com.ibm.team.workitem.attribute.projectarea       | projectArea           |
+| com.ibm.team.workitem.attribute.resolver          | resolver              |
+| TAGS                                              | internalTags          |
+| com.ibm.team.workitem.attribute.creator           | creator               |
+| com.ibm.team.workitem.attribute.modified          | modified              |
+| ID                                                | id                    |
+| DESCRIPTION                                       | description           |
+| TIME_SPENT                                        | timeSpent             |
+| com.ibm.team.workitem.attribute.correctedestimate | correctedEstimate     |
+| com.ibm.team.workitem.attribute.creationdate      | creationDate          |
+| com.ibm.team.workitem.attribute.owner             | owner                 |
+| RESOLUTION_DATE                                   | resolutionDate        |
+| FOUND_IN                                          | foundIn               |
+| com.ibm.team.workitem.attribute.target            | target                |
+| PRIORITY                                          | internalPriority      |
+| com.ibm.team.workitem.attribute.duration          | duration              |
+| ESTIMATE                                          | duration              |
+| com.ibm.team.workitem.attribute.description       | description           |
+| FILED_AGAINST                                     | category              |
+| com.ibm.team.workitem.attribute.tags              | internalTags          |
+| com.ibm.team.workitem.attribute.resolutiondate    | resolutionDate        |
+| RESOLUTION                                        | internalResolution    |
+| com.ibm.team.workitem.attribute.id                | id                    |
+| com.ibm.team.workitem.attribute.timespent         | timeSpent             |
+| com.ibm.team.workitem.attribute.workitemtype      | workItemType          |
+| STATE                                             | internalState         |
+| com.ibm.team.workitem.attribute.modifiedby        | modifiedBy            |
+| com.ibm.team.workitem.attribute.priority          | internalPriority      |
+| DUE_DATE                                          | dueDate               |
+| TYPE                                              | workItemType          |
+| SEVERITY                                          | internalSeverity      |
+| CORRECTED_ESTIMATE                                | correctedEstimate     |
+| com.ibm.team.workitem.attribute.state             | internalState         |
 


### PR DESCRIPTION
Cleaned up the readme file using markdown. I probably missed some details, but this should be a good start.

You can have a look at the cleaned up version on my fork: https://github.com/SBI-/work-item-command-line