### PR TITLE
Fix export and import resolutions

### DIFF
--- a/com.ibm.js.team.workitem.commandline/Launches/WorkitemCommandLine - Export Work Items - Resolution and ID.launch
+++ b/com.ibm.js.team.workitem.commandline/Launches/WorkitemCommandLine - Export Work Items - Resolution and ID.launch
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?><launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/com.ibm.js.team.workitem.commandline/src/com/ibm/js/team/workitem/commandline/WorkitemCommandLine.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.ibm.js.team.workitem.commandline.WorkitemCommandLine"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-exportworkitems /ignoreErrors repository=&quot;https://clm.example.com:9443/ccm&quot; user=myadmin password=myadmin projectArea=&quot;JKE Banking (Change Management)&quot; exportFile=&quot;C:\aaTemp\Export\ResolutionTest.csv&quot; query=&quot;Resolution 18&quot; delimiter=&quot;;&quot; /suppressAttributeExceptions columns=&quot;id,internalResolution&quot;"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="com.ibm.js.team.workitem.commandline"/>
+</launchConfiguration>

--- a/com.ibm.js.team.workitem.commandline/Launches/WorkitemCommandLine - Import Work Items - Resoultion.launch
+++ b/com.ibm.js.team.workitem.commandline/Launches/WorkitemCommandLine - Import Work Items - Resoultion.launch
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?><launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/com.ibm.js.team.workitem.commandline/src/com/ibm/js/team/workitem/commandline/WorkitemCommandLine.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.ibm.js.team.workitem.commandline.WorkitemCommandLine"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-importworkitems /ignoreErrors repository=&quot;https://clm.example.com:9443/ccm&quot; user=ralph password=ralph projectArea=&quot;JKE Banking (Change Management)&quot; importFile=&quot;C:\aaTemp\Export\ResolutionTest.csv&quot; delimiter=&quot;;&quot;"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="com.ibm.js.team.workitem.commandline"/>
+</launchConfiguration>

--- a/com.ibm.js.team.workitem.commandline/src/com/ibm/js/team/workitem/commandline/commands/ImportWorkItemsCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/com/ibm/js/team/workitem/commandline/commands/ImportWorkItemsCommand.java
@@ -694,7 +694,9 @@ public class ImportWorkItemsCommand extends AbstractWorkItemModificationCommand 
 			String attributeID, String targetValue) {
 		// If the parameter has no value, we don't process it.
 		if (targetValue.equals("")) {
-			return;
+			// @see https://github.com/jazz-community/work-item-command-line/issues/16
+			// TODO: Defect, we want to be able to clear attributes. 
+			return;  
 		}
 		// Try to get the attribute from the header mapping
 		IAttribute attribute = headerMapping.getAttribute(attributeID);

--- a/com.ibm.js.team.workitem.commandline/src/com/ibm/js/team/workitem/commandline/helper/WorkItemExportHelper.java
+++ b/com.ibm.js.team.workitem.commandline/src/com/ibm/js/team/workitem/commandline/helper/WorkItemExportHelper.java
@@ -71,6 +71,7 @@ import com.ibm.team.workitem.common.model.IDeliverable;
 import com.ibm.team.workitem.common.model.IDeliverableHandle;
 import com.ibm.team.workitem.common.model.IEnumeration;
 import com.ibm.team.workitem.common.model.ILiteral;
+import com.ibm.team.workitem.common.model.IResolution;
 import com.ibm.team.workitem.common.model.IState;
 import com.ibm.team.workitem.common.model.ISubscriptions;
 import com.ibm.team.workitem.common.model.IWorkItem;
@@ -239,6 +240,10 @@ public class WorkItemExportHelper {
 			// Handle states
 			return calculateStateAsString(workItem);
 		}
+		if (attribute.getIdentifier().equals(IWorkItem.RESOLUTION_PROPERTY)) {
+			// Handle states
+			return calculateResolutionAsString(workItem);
+		}
 		if (attribType.equals(AttributeTypes.APPROVALS)) {
 			// Handle approvals
 			return calculateApprovalsAsString(workItem);
@@ -386,6 +391,22 @@ public class WorkItemExportHelper {
 			throw new WorkItemCommandLineException(
 					"AttributeType not yet supported: " + attribType + " ID " + attribute.getIdentifier());
 		}
+	}
+
+	/**
+	 * Calculate the resolution attribute.
+	 * 
+	 * @param workItem
+	 * @return
+	 * @throws TeamRepositoryException 
+	 */
+	private String calculateResolutionAsString(IWorkItem workItem) throws TeamRepositoryException {
+		Identifier<IResolution> resolution = workItem.getResolution2();	
+		IWorkflowInfo workflowInfo;
+			workflowInfo = getWorkItemCommon().getWorkflow(
+					workItem.getWorkItemType(),
+					workItem.getProjectArea(), getMonitor());
+		return workflowInfo.getResolutionName(resolution);
 	}
 
 	/**

--- a/com.ibm.js.team.workitem.commandline/src/com/ibm/js/team/workitem/commandline/helper/WorkItemUpdateHelper.java
+++ b/com.ibm.js.team.workitem.commandline/src/com/ibm/js/team/workitem/commandline/helper/WorkItemUpdateHelper.java
@@ -2429,7 +2429,7 @@ public class WorkItemUpdateHelper {
 		for (Identifier<IResolution> resolution : resolutions) {
 			if (workflowInfo.getResolutionName(resolution).equals(value)) {
 				return resolution;
-			} else if (resolution.toString().equals(value)) {
+			} else if (resolution.getStringIdentifier().equals(value)) {
 				return resolution;
 			}
 		}


### PR DESCRIPTION
Resoolutions are now handled correctly during import if a value is given. If the falue is provided as id or as display name, both cases are handled.

Currently teh resolution is not deleted in an import for values "", because "" is not treated correctly.