### PR TITLE
Fix to get the trace logger working correctly for ValidateOSLCLinksCommand.

### DIFF
--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ValidateOSLCLinksCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ValidateOSLCLinksCommand.java
@@ -211,11 +211,11 @@ public class ValidateOSLCLinksCommand extends AbstractTeamRepositoryCommand impl
 	@Override
 	public OperationResult process() throws TeamRepositoryException {
 		// Set the logging level. Changed for Log4J2
-		Configurator.setLevel(LogManager.getLogger(logger).getName(),Level.WARN);
+		Configurator.setLevel(logger.getName(),Level.WARN);
 		if (getParameterManager().hasSwitch(SWITCH_DEBUG))
-			Configurator.setLevel(LogManager.getLogger(logger).getName(),Level.DEBUG);
+			Configurator.setLevel(logger.getName(),Level.DEBUG);
 		if (getParameterManager().hasSwitch(SWITCH_TRACE))
-			Configurator.setLevel(LogManager.getLogger(logger).getName(),Level.TRACE);
+			Configurator.setLevel(logger.getName(),Level.TRACE);
 
 		// Get the parameters such as project area name and
 		// run the operation


### PR DESCRIPTION
There may need to be a deeper dive into the logging as a whole as the logging was not working for this class with log4j2.  But this resolves the issue with this one command.  