### PR TITLE
Cleanup libraries and classpath information.  Fix all compiler warnings

### DIFF
--- a/com.ibm.js.team.workitem.commandline/.classpath
+++ b/com.ibm.js.team.workitem.commandline/.classpath
@@ -7,12 +7,12 @@
 	</classpathentry>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="src" path="src/main/resources"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/702SR1_JavaLIb"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/PlainJavaApi"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/OpenCSV"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Commons-lang"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/SLF4J"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JunoAll"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/EWMCommon"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Jena"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JenaCore"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/com.ibm.js.team.workitem.commandline/.classpath
+++ b/com.ibm.js.team.workitem.commandline/.classpath
@@ -5,14 +5,14 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="src" path="src/main/resources"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/PlainJavaApi"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/702SR1_JavaLIb"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/OpenCSV"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Commons-lang"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JenaCore"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/SLF4J"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JunoAll"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/EWMCommon"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Jena"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/com.ibm.js.team.workitem.commandline/Launches/WorkitemCommandLine - No command.launch
+++ b/com.ibm.js.team.workitem.commandline/Launches/WorkitemCommandLine - No command.launch
@@ -1,10 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?><launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/WorkitemCommandLine.java"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.ibm.js.team.workitem.commandline.WorkitemCommandLine"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="com.ibm.js.team.workitem.commandline"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/WorkitemCommandLine.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.ibm.js.team.workitem.commandline.WorkitemCommandLine"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="com.ibm.js.team.workitem.commandline"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="com.ibm.js.team.workitem.commandline"/>
 </launchConfiguration>

--- a/com.ibm.js.team.workitem.commandline/META-INF/MANIFEST.MF
+++ b/com.ibm.js.team.workitem.commandline/META-INF/MANIFEST.MF
@@ -4,15 +4,5 @@ Bundle-Name: WorkitemCommandLine
 Bundle-SymbolicName: com.ibm.js.team.workitem.commandline;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: IBM
-Require-Bundle: com.ibm.team.workitem.common,
- com.ibm.team.workitem.client,
- com.ibm.team.repository.client,
- com.ibm.team.process.common,
- com.ibm.team.process.client,
- com.ibm.team.build.common,
- com.ibm.team.build.client,
- com.ibm.team.scm.common,
- com.ibm.team.scm.client,
- org.eclipse.core.runtime
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Multi-Release: true

--- a/com.ibm.js.team.workitem.commandline/lib/ReadMe.txt
+++ b/com.ibm.js.team.workitem.commandline/lib/ReadMe.txt
@@ -18,6 +18,7 @@ https://commons.apache.org/proper/commons-lang/download_lang.cgi
 Version 3-3.1 works.
 
 Rename the jar file e.g. commons-lang3-3.1.jar to commons-lang.jar
+The org.apache.commons.lang jar can also be found in the EWM server install.
 
 1.a Copy the library file commons-lang.jar into /com.ibm.js.team.workitem.commandline/lib to be able to run from Eclipse.
 1.b Place the library commons-lang.jar into the folder lib in the WCL folder (see /com.ibm.js.team.workitem.commandline/ReadMe - HowToRelease.txt). 

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ExportCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ExportCommand.java
@@ -314,7 +314,6 @@ public class ExportCommand extends AbstractTeamRepositoryCommand {
 	 * @return
 	 * @throws WorkItemCommandLineException
 	 */
-	@SuppressWarnings("deprecation")
 	private CSVWriter createWriter(String filePath) throws WorkItemCommandLineException {
 		CSVWriter writer = null;
 		try {

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/FindEnumerationIdConflictsCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/FindEnumerationIdConflictsCommand.java
@@ -14,7 +14,7 @@ import java.net.URI;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/FindEnumerationIdConflictsCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/FindEnumerationIdConflictsCommand.java
@@ -43,7 +43,6 @@ import com.ibm.team.workitem.client.IWorkItemClient;
  * Each project area must be manually modified by the administrator to change
  * the reference.
  */
-@SuppressWarnings("deprecation")
 public class FindEnumerationIdConflictsCommand extends AbstractTeamRepositoryCommand implements IWorkItemCommand {
 
 	private Logger logger = LogManager.getLogger(FindEnumerationIdConflictsCommand.class);

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ImportWorkItemsCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ImportWorkItemsCommand.java
@@ -78,7 +78,6 @@ import com.opencsv.CSVReader;
  * com.ibm.team.workitem.rcp.core.internal.bugzilla.mappers.BugzillaMapping.ValueMapping;
  * 
  */
-@SuppressWarnings("restriction")
 public class ImportWorkItemsCommand extends AbstractWorkItemModificationCommand {
 
 	private static final String HTML_PATH_SLASH = "/";
@@ -565,7 +564,7 @@ public class ImportWorkItemsCommand extends AbstractWorkItemModificationCommand 
 		} else {
 			IWorkItem workItem = WorkItemUtil.resolveWorkItem(handle, IWorkItem.SMALL_PROFILE, getWorkItemCommon(),
 					getMonitor());
-			String newWorkItemID = new Integer(workItem.getId()).toString();
+			String newWorkItemID = Integer.toString(workItem.getId());
 			this.appendResultString("Created work item " + newWorkItemID + ".");
 			mapNewWorkItemID(originalWorkItemID, newWorkItemID);
 		}
@@ -728,7 +727,7 @@ public class ImportWorkItemsCommand extends AbstractWorkItemModificationCommand 
 	}
 
 	private void resetUniqueID() {
-		fUniqueID = new Integer(0);
+		fUniqueID = 0;
 	}
 
 	private Integer getUniqueID() {
@@ -1122,7 +1121,7 @@ public class ImportWorkItemsCommand extends AbstractWorkItemModificationCommand 
 	 * @return
 	 */
 	private Integer getNextUniqueParameterId() {
-		return new Integer(uniqueParamCount++);
+		return uniqueParamCount++;
 	}
 
 	private boolean isIgnoreEmptyTargetValues() {

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/MigrateWorkItemAttributeCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/MigrateWorkItemAttributeCommand.java
@@ -299,7 +299,7 @@ public class MigrateWorkItemAttributeCommand extends AbstractTeamRepositoryComma
 	 * @return
 	 */
 	private String getWorkItemIDString(IWorkItem workItem) {
-		return new Integer(workItem.getId()).toString();
+		return Integer.toString(workItem.getId());
 	}
 
 	/**

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ValidateUserAllocationsCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ValidateUserAllocationsCommand.java
@@ -7,11 +7,8 @@
  *******************************************************************************/
 package com.ibm.js.team.workitem.commandline.commands;
 
-import java.util.HashMap;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-
+import org.apache.logging.log4j.Logger;
 
 import com.ibm.js.team.workitem.commandline.IWorkItemCommandLineConstants;
 import com.ibm.js.team.workitem.commandline.OperationResult;
@@ -25,7 +22,6 @@ import com.ibm.js.team.workitem.commandline.utils.ProcessAreaUtil;
 import com.ibm.team.process.common.IProjectArea;
 import com.ibm.team.repository.common.IContributorHandle;
 import com.ibm.team.repository.common.TeamRepositoryException;
-import com.ibm.team.repository.transport.client.ITeamRawRestServiceClient;
 
 /**
  * This command checks the user allocation of a project area.
@@ -40,8 +36,6 @@ public class ValidateUserAllocationsCommand extends AbstractTeamRepositoryComman
 	private static final String SWITCH_DEBUG = "debug";
 
 	private IProjectArea projectArea;
-	private HashMap<String, ITeamRawRestServiceClient> repoClients = new HashMap<String, ITeamRawRestServiceClient>();
-
 	/**
 	 * @param parameterManager
 	 */

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ValidateUserAllocationsRESTCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ValidateUserAllocationsRESTCommand.java
@@ -7,11 +7,8 @@
  *******************************************************************************/
 package com.ibm.js.team.workitem.commandline.commands;
 
-import java.util.HashMap;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 
 import com.ibm.js.team.workitem.commandline.IWorkItemCommandLineConstants;
 import com.ibm.js.team.workitem.commandline.OperationResult;
@@ -25,7 +22,6 @@ import com.ibm.js.team.workitem.commandline.utils.ProcessAreaUtil;
 import com.ibm.team.process.common.IProjectArea;
 import com.ibm.team.repository.common.IContributorHandle;
 import com.ibm.team.repository.common.TeamRepositoryException;
-import com.ibm.team.repository.transport.client.ITeamRawRestServiceClient;
 
 /**
  * This command checks the user allocation of a project area.
@@ -40,8 +36,6 @@ public class ValidateUserAllocationsRESTCommand extends AbstractTeamRepositoryCo
 	private static final String SWITCH_DEBUG = "debug";
 
 	private IProjectArea projectArea;
-	private HashMap<String, ITeamRawRestServiceClient> repoClients = new HashMap<String, ITeamRawRestServiceClient>();
-
 	/**
 	 * @param parameterManager
 	 */

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ValidateWorkItemStatesCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/ValidateWorkItemStatesCommand.java
@@ -68,7 +68,6 @@ public class ValidateWorkItemStatesCommand extends AbstractTeamRepositoryCommand
 	private boolean isLocal= false;
 	private boolean isLinksOnly= false;
 	private boolean isStatesOnly= false;
-	private boolean isVerbose= false;
 	private boolean useRest= true;
 	private boolean isTrimHtml= false;
 	private int depth= 3;
@@ -192,7 +191,6 @@ public class ValidateWorkItemStatesCommand extends AbstractTeamRepositoryCommand
 		if (getParameterManager().hasSwitch(SWITCH_TRIM_HTML))
 			isTrimHtml= true;
 		if (getParameterManager().hasSwitch(SWITCH_VERBOSE)) {
-			isVerbose= true;
 		}
 		
 		String depthString = getParameterManager()

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/framework/AbstractWorkItemModificationCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/framework/AbstractWorkItemModificationCommand.java
@@ -33,7 +33,6 @@ import com.ibm.team.workitem.common.model.ItemProfile;
  * does the error handling.
  * 
  */
-@SuppressWarnings("restriction")
 public abstract class AbstractWorkItemModificationCommand extends AbstractTeamRepositoryCommand {
 
 	public final static String UPDATE_BACK_LINKS = IAdditionalSaveParameters.UPDATE_BACKLINKS;

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/ItemStateImportHelper.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/ItemStateImportHelper.java
@@ -280,7 +280,7 @@ public class ItemStateImportHelper {
 			
 			ByteArrayInputStream inStream = new ByteArrayInputStream((newContent).getBytes());
 			com.ibm.team.repository.transport.client.ITeamRawRestServiceClient.IRawRestClientConnection.Response response = connection
-					.doPost(inStream, new Long(newContent.length()), "application/x-www-form-urlencoded");
+					.doPost(inStream, Long.valueOf(newContent.length()), "application/x-www-form-urlencoded");
 
 			InputStream inputStream = response.getResponseStream();			
 			char[] resultCharArray = IOUtils.toCharArray(inputStream, StandardCharsets.UTF_8.toString());

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/ProcessAreaOslcHelper.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/ProcessAreaOslcHelper.java
@@ -20,7 +20,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.logging.log4j.Logger;
 
 import org.w3c.dom.Document;
@@ -55,7 +55,6 @@ import com.ibm.team.repository.transport.client.ITeamRawRestServiceClient.IRawRe
  * Class helps with accessing OSLC Link
  * 
  */
-@SuppressWarnings({ "deprecation", "restriction" })
 public class ProcessAreaOslcHelper {
 	public static final String CONFIGURATION_MANAGEMENT_CONTEXT_HEADER_NAME = "X-OLSC-Configuration-Context"; //$NON-NLS-1$
 	public static final String OSLC_CATALOG_URI_PATH = "/oslc/workitems/catalog"; //$NON-NLS-1$

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemExportHelper.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemExportHelper.java
@@ -910,7 +910,7 @@ public class WorkItemExportHelper {
 		if (isRTCEclipseExport()) {
 			return getExistingWorkitemPrefix() + workItem.getId();
 		}
-		return new Integer(workItem.getId()).toString();
+		return Integer.toString(workItem.getId());
 	}
 
 	/**

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemLocalLinkHelper.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemLocalLinkHelper.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -29,7 +28,6 @@ import com.ibm.team.workitem.common.model.WorkItemEndPoints;
  * Class helps with accessing OSLC Link
  * 
  */
-@SuppressWarnings({ "deprecation" })
 public class WorkItemLocalLinkHelper {
 	// public static final IEndPointDescriptor CHANGE_SET = ILinkTypeRegistry.INSTANCE.getLinkType("com.ibm.team.scm.ChangeSet").getTargetEndPointDescriptor();
 

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemOslcLinkHelper.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemOslcLinkHelper.java
@@ -47,7 +47,6 @@ import com.ibm.team.repository.common.transport.HttpUtil;
 import com.ibm.team.repository.transport.client.ITeamRawRestServiceClient;
 import com.ibm.team.repository.transport.client.ITeamRawRestServiceClient.IRawRestClientConnection;
 import com.ibm.team.workitem.common.model.IWorkItem;
-import com.ibm.team.workitem.common.model.IWorkItemReferences;
 import com.ibm.team.workitem.common.model.ItemURI;
 import com.ibm.team.workitem.common.model.WorkItemLinkTypes;
 
@@ -165,16 +164,18 @@ public class WorkItemOslcLinkHelper {
 		}
 	};
 	private static Map<String, Boolean> EXCLUDED_TYPES = new HashMap<String, Boolean>() {
+		private static final long serialVersionUID = 1543297740215627174L;
+
 		{
-			put("relatedArtifact", new Boolean(true));
-			put("com.ibm.team.workitem.linktype.relatedArtifact", new Boolean(true));
+			put("relatedArtifact", Boolean.TRUE);
+			put("com.ibm.team.workitem.linktype.relatedArtifact", Boolean.TRUE);
 //			put("com.ibm.team.workitem.linktype.cm.affectedByDefect", new Boolean(true)); // does not work? TODO: Test affectedByDefect
-			put("com.ibm.team.workitem.linktype.textualReference", new Boolean(true)); // not needed
+			put("com.ibm.team.workitem.linktype.textualReference", Boolean.TRUE); // not needed
 
 			// "com.ibm.team.workitem.linktype.qm.relatedExecutionRecord" not yet supported
 			put(WorkItemLinkTypes.RELATED_EXECUTION_RECORD /*
 															 * "com.ibm.team.workitem.linktype.qm.relatedExecutionRecord"
-															 */, new Boolean(true));
+															 */, Boolean.TRUE);
 		}
 	};
 
@@ -319,9 +320,9 @@ public class WorkItemOslcLinkHelper {
 		return currentWorkItemURI; 
 	}
 
-	private IWorkItemReferences getWorkItemTargetReferences(ValidateOSLCLinksCommand command, IWorkItem workItem, Logger logger) throws TeamRepositoryException {
-		return command.getWorkItemService().resolveWorkItemReferences(workItem, command.getMonitor()); 
-	}
+//	private IWorkItemReferences getWorkItemTargetReferences(ValidateOSLCLinksCommand command, IWorkItem workItem, Logger logger) throws TeamRepositoryException {
+//		return command.getWorkItemService().resolveWorkItemReferences(workItem, command.getMonitor()); 
+//	}
 
 //	private String getConfigurationManagementUriByLinkType(IEndPointDescriptor endPointDescriptor, IWorkItem workItem,
 //			Logger logger) {

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemStateHelper.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemStateHelper.java
@@ -34,20 +34,15 @@ import com.ibm.js.team.workitem.commandline.commands.ValidateWorkItemStatesComma
 import com.ibm.js.team.workitem.commandline.utils.AttachmentUtil;
 import com.ibm.juno.core.utils.IOUtils;
 import com.ibm.team.calm.foundation.common.SecureDocumentBuilderFactory;
-import com.ibm.team.foundation.common.text.XMLString;
 import com.ibm.team.repository.client.ITeamRepository;
 import com.ibm.team.repository.common.IAuditable;
 import com.ibm.team.repository.common.IAuditableHandle;
-import com.ibm.team.repository.common.IItemType;
 import com.ibm.team.repository.common.transport.HttpUtil;
 import com.ibm.team.repository.transport.client.ITeamRawRestServiceClient;
 import com.ibm.team.repository.transport.client.ITeamRawRestServiceClient.IRawRestClientConnection;
 import com.ibm.team.workitem.common.IWorkItemCommon;
 import com.ibm.team.workitem.common.model.IAttributeHandle;
-import com.ibm.team.workitem.common.model.IComments;
-import com.ibm.team.workitem.common.model.IState;
 import com.ibm.team.workitem.common.model.IWorkItem;
-import com.ibm.team.workitem.common.model.Identifier;
 
 /**
  * Helper handling of conversion of work item properties into strings.
@@ -67,12 +62,8 @@ public class WorkItemStateHelper {
 	private IProgressMonitor fMonitor;
 	private ITeamRepository fTeamRepository;
 	private String fOutputFolder = null;
-	private String fWorkItemId = "000";
-
-
 	public WorkItemStateHelper(ITeamRepository fTeamRepository, String workItemId, IProgressMonitor fMonitor) {
 		super();
-		this.fWorkItemId= workItemId;
 		this.fMonitor = fMonitor;
 		this.fTeamRepository = fTeamRepository;
 	}
@@ -745,13 +736,13 @@ public class WorkItemStateHelper {
 				}
 				
 				
-				IItemType type = workItem.getItemType();
-				IComments comments = workItem.getComments();
-				XMLString description = workItem.getHTMLDescription();
-				XMLString summary = workItem.getHTMLSummary();
-				Identifier<IState> state = workItem.getState2();
-				List<String> tagList = workItem.getTags2();
-				String itemType= workItem.getWorkItemType();
+//				IItemType type = workItem.getItemType();
+//				IComments comments = workItem.getComments();
+//				XMLString description = workItem.getHTMLDescription();
+//				XMLString summary = workItem.getHTMLSummary();
+//				Identifier<IState> state = workItem.getState2();
+//				List<String> tagList = workItem.getTags2();
+//				String itemType= workItem.getWorkItemType();
 				
 				command.logger.trace("Work item verified via API.");
 				} catch (Exception e) {
@@ -762,6 +753,7 @@ public class WorkItemStateHelper {
 		}
 		
 		private List<String> visitedApiStates= new ArrayList<String>();
+		@SuppressWarnings("unchecked")
 		public void validateAttributeStateWithItemAPI(ValidateWorkItemStatesCommand command, IAuditableHandle attributeHandle, String attributeName, String searchString) throws Exception {
 			
 			if (attributeHandle == null || attributeHandle.getItemId() == null) {
@@ -823,7 +815,7 @@ public class WorkItemStateHelper {
 		private boolean madeFolder= false;
 		private boolean madeTrimmedFolder= false;
 		
-		private static final String REGEX_SPAN= "&lt;(span|SPAN)[^>]*>";
+//		private static final String REGEX_SPAN= "&lt;(span|SPAN)[^>]*>";
 		private static final String REGEX_ESPAN= "&lt;/(span|SPAN)[^>]*>";
 		private static final String REGEX_B= "&lt;(b|B)[^>]*>";
 		private static final String REGEX_EB= "&lt;/(b|B)[^>]*>";

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemTypeHelper.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemTypeHelper.java
@@ -167,7 +167,7 @@ public class WorkItemTypeHelper {
 	 */
 	private String printAttributesAndTypes(List<?> items, IProgressMonitor monitor) {
 		String message = "";
-		message = message + "\tNumber of attributes: " + new Integer(items.size()).toString() + "\n";
+		message = message + "\tNumber of attributes: " + Integer.toString(items.size()) + "\n";
 		for (@SuppressWarnings("rawtypes")
 		Iterator iterator = items.iterator(); iterator.hasNext();) {
 			Object object = iterator.next();

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemUpdateHelper.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/WorkItemUpdateHelper.java
@@ -105,7 +105,6 @@ import com.ibm.team.workitem.common.workflow.IWorkflowInfo;
  * Class helps with manipulating work item attribute values.
  * 
  */
-@SuppressWarnings("restriction")
 public class WorkItemUpdateHelper {
 
 	private static final int XML_GROWTH_CONSTANT = 50;
@@ -643,7 +642,7 @@ public class WorkItemUpdateHelper {
 								+ com.ibm.js.team.workitem.commandline.framework.ParameterValue.MODE_SET + " modes.");
 			}
 			if (attribType.equals(AttributeTypes.BOOLEAN)) {
-				return new Boolean(parameter.getValue());
+				return Boolean.getBoolean(parameter.getValue());
 			}
 			if (AttributeTypes.NUMBER_TYPES.contains(attribType)) {
 				// different number types
@@ -654,13 +653,13 @@ public class WorkItemUpdateHelper {
 						isEmpty = true;
 					}
 					if (attribType.equals(AttributeTypes.INTEGER)) {
-						return new Integer(value);
+						return Integer.getInteger(value);
 					}
 					if (attribType.equals(AttributeTypes.LONG)) {
-						return new Long(value);
+						return Long.getLong(value);
 					}
 					if (attribType.equals(AttributeTypes.FLOAT)) {
-						return new Float(value);
+						return Float.parseFloat(value);
 					}
 					if (attribType.equals(AttributeTypes.DECIMAL)) {
 						return new BigDecimal(value);
@@ -2852,7 +2851,6 @@ public class WorkItemUpdateHelper {
 	 * @return the literal ID or null
 	 * @throws TeamRepositoryException
 	 */
-	@SuppressWarnings("unused")
 	// Used if no exact match possible
 	public Identifier<? extends ILiteral> getEnumerationLiteralStartsWithString(IAttributeHandle attributeHandle,
 			String literalNamePrefix) throws TeamRepositoryException {

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/utils/QueryUtil.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/utils/QueryUtil.java
@@ -38,7 +38,6 @@ import com.ibm.team.workitem.common.query.QueryTypes;
  * And Utility Class to get results from queries
  * 
  */
-@SuppressWarnings("restriction")
 public class QueryUtil {
 
 	/**

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/utils/SimpleDateFormatUtil.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/utils/SimpleDateFormatUtil.java
@@ -114,11 +114,11 @@ public class SimpleDateFormatUtil {
 		int hoursIndex = duration.indexOf(DURATION_HOURS);
 		int minsIndex = duration.indexOf(DURATION_MINUTES);
 		if (hoursIndex < 0 && minsIndex < 0) {
-			return new Long(duration);
+			return Long.getLong(duration);
 		}
 		if (hoursIndex > 0) {
 			String hours = duration.substring(0, hoursIndex - 1).trim();
-			time += TimeUnit.HOURS.toMillis(new Long(hours));
+			time += TimeUnit.HOURS.toMillis(Long.getLong(hours));
 		}
 		if (minsIndex > 0) {
 			int start = 0;
@@ -126,7 +126,7 @@ public class SimpleDateFormatUtil {
 				start = hoursIndex + DURATION_HOURS.length();
 			}
 			String minutes = duration.substring(start, duration.length() - DURATION_MINUTES.length()).trim();
-			time += TimeUnit.MINUTES.toMillis(new Long(minutes));
+			time += TimeUnit.MINUTES.toMillis(Long.getLong(minutes));
 		}
 		return time;
 	}

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/utils/WorkItemUtil.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/utils/WorkItemUtil.java
@@ -40,7 +40,7 @@ public class WorkItemUtil {
 			IProgressMonitor monitor) throws TeamRepositoryException {
 		Integer idVal;
 		try {
-			idVal = new Integer(id);
+			idVal = Integer.getInteger(id);
 		} catch (NumberFormatException e) {
 			throw new WorkItemCommandLineException(" WorkItem ID: Number format exception, ID is not a number: " + id);
 		}


### PR DESCRIPTION
Removing a bunch of unused libraries entries that were cluttering up the manifest and classpath.

Cleaned up all the source to remove all the compiler warnings except for the two apparently incomplete classes:
ValidateWorkItemStatesCommand
UserAllocationHelper

