### PR TITLE
Clean up non-log4j messages and fully implement loggers for commands

### DIFF
--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/IWorkItemCommandLineConstants.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/IWorkItemCommandLineConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2023 IBM Corporation
+ * Copyright (c) 2015-2024 IBM Corporation
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
@@ -108,6 +108,10 @@ public interface IWorkItemCommandLineConstants {
 	// Switches for RMI
 	public static final String SWITCH_RMISERVER = "rmiServer";
 	public static final String SWITCH_RMICLIENT = "rmiClient";
+	
+	public static final String SWITCH_DEBUG = "debug";
+	public static final String SWITCH_TRACE = "trace";
+
 
 	// Import, Export constants
 
@@ -154,4 +158,9 @@ public interface IWorkItemCommandLineConstants {
 	public static final String PARAMETER_SHARING_TARGETS_EXAMPLE = "\"JKE Banking(Change Management),JKE Banking(Change Management)/Business Recovery Matters\"";
 
 	public static final String UNASSIGNED_USER = "Unassigned";
+
+	//Logging category for the main command initialization.
+	public static final String GLOBAL_COMMAND_LOGGER = "global.command.logger";
+	//Logging category for all commands.
+	public static final String WORK_ITEM_COMMAND_LOGGER = "work.item.command.logger";
 }

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/framework/AbstractTeamRepositoryCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/framework/AbstractTeamRepositoryCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 IBM Corporation
+ * Copyright (c) 2015-2024 IBM Corporation
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Set;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 import com.ibm.js.team.workitem.commandline.IWorkItemCommandLineConstants;
@@ -47,6 +49,15 @@ public abstract class AbstractTeamRepositoryCommand extends AbstractCommand {
 	private ITeamRepository fTeamRepository;
 	private IExpensiveScenarioService fScenarioService;
 
+	public Logger fLogger = LogManager.getLogger(IWorkItemCommandLineConstants.WORK_ITEM_COMMAND_LOGGER); 
+	
+	public Logger getLogger() {
+		if (fLogger != null) {
+			return fLogger;
+		}
+		return LogManager.getLogger(IWorkItemCommandLineConstants.WORK_ITEM_COMMAND_LOGGER); 
+	}
+	
 	protected AbstractTeamRepositoryCommand(ParameterManager parametermanager) {
 		super(parametermanager);
 	}
@@ -76,7 +87,7 @@ public abstract class AbstractTeamRepositoryCommand extends AbstractCommand {
 		// I need the team platform to be started here.
 		// To be able to access the aliases
 		if (!TeamPlatform.isStarted()) {
-			System.out.println("Starting Team Platform ...");
+			getLogger().debug("Starting Team Platform ...");
 			TeamPlatform.startup();
 		}
 		super.initialize();
@@ -210,7 +221,7 @@ public abstract class AbstractTeamRepositoryCommand extends AbstractCommand {
 		for (String line : fileContent) {
 			String[] elements= line.split(" ");
 			if (elements.length< 3) {
-				System.out.println("Invalid password file line: " + line);
+				getLogger().error("Invalid password file line: " + line);
 			} else {
 				key= elements[0];
 			}
@@ -237,7 +248,7 @@ public abstract class AbstractTeamRepositoryCommand extends AbstractCommand {
 				return new String[] { pwMap.get(key)[1],  pwMap.get(key)[2]};
 			}
 		}		
-		System.out.println("No userid and password found for: " + repositoryUrl);
+		getLogger().error("No userid and password found for: " + repositoryUrl);
 		
 		return null;
 	}
@@ -279,6 +290,7 @@ public abstract class AbstractTeamRepositoryCommand extends AbstractCommand {
 	 * @return
 	 * @throws TeamRepositoryException
 	 */
+	boolean reportedId = false;
 	protected ITeamRepository login(String repositoryUrl) throws TeamRepositoryException {
 		String passwordFile = getParameterManager()
 				.consumeParameter(IWorkItemCommandLineConstants.PARAMETER_PASSWORD_FILE_PROPERTY);
@@ -300,12 +312,17 @@ public abstract class AbstractTeamRepositoryCommand extends AbstractCommand {
 		}
 		
 		if (user == null) {
-			System.out.println("No user specified.");
+			getLogger().error("No user specified.");
 			System.exit(500);
 		}
 		if (password == null) {
-			System.out.println("No password specified.");
+			getLogger().error("No password specified.");
 			System.exit(500);
+		}
+		//If debug is on, log first time user logs in.
+		if (getLogger().isDebugEnabled() && !reportedId) {			
+			fLogger.debug("Logging in as: " + user);
+			reportedId= true;
 		}
 		
 		ITeamRepository teamRepository = TeamPlatform.getTeamRepositoryService().getTeamRepository(repositoryUrl);

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/utils/ProcessAreaUtil.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/utils/ProcessAreaUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 IBM Corporation
+ * Copyright (c) 2015-2024 IBM Corporation
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE file for details.
@@ -13,6 +13,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 import com.ibm.team.process.client.IProcessClientService;
@@ -35,6 +37,8 @@ import com.ibm.team.repository.common.UUID;
  */
 public class ProcessAreaUtil {
 
+	private static Logger fLogger = LogManager.getLogger();
+	
 	public static final String PATH_SEPARATOR = "/";
 
 	/**
@@ -146,7 +150,7 @@ public class ProcessAreaUtil {
 			URI nameUri = new URI(url.getProtocol(), url.getUserInfo(), IDN.toASCII(url.getHost()), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
 			String nameEncodedURLQuery=nameUri.toASCIIString().split("\\?")[1];
 		    encodedName =  nameEncodedURLQuery.split("=")[1];
-			System.out.println("URL Encoded Project Area Name: " + encodedName);
+			fLogger.debug("URL Encoded Project Area Name: " + encodedName);
 		} catch (MalformedURLException e) {
 			// will never happen
 			e.printStackTrace();

--- a/com.ibm.js.team.workitem.commandline/src/main/resources/log4j2.xml
+++ b/com.ibm.js.team.workitem.commandline/src/main/resources/log4j2.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed Materials - Property of IBM
+    (c) Copyright IBM Corporation 2022. All Rights Reserved.
+   
+    Note to U.S. Government Users Restricted Rights:  
+    Use, duplication or disclosure restricted by GSA ADP Schedule 
+    Contract with IBM Corp. 
+ -->
+ <Configuration name="ApplicationLogging" status="error" monitorInterval="10">
+    <Properties>
+        <Property name="basePath">.</Property>
+    </Properties>
+    <Appenders>
+    	<Routing name="Routing">
+    		<Routes pattern="$${main:\-log}">
+    			
+    			<!-- This route is chosen if there is no log file specified on the command line -->
+    			<Route key="$${main:\-log}">
+			        <!-- Console Appender -->
+			        <Console name="STDOUT" target="SYSTEM_OUT">
+				              <!--  PatternLayout pattern="%d{dd MMM yyyy HH:mm:ss,SSSZ}[%t] %5p %c: %m%n" />  -->
+							  <PatternLayout pattern="%d{ddMMMyyyy HH:mm:ss,SSS}| %5p: %m%n" />			              
+			        </Console>
+    			</Route>
+    			
+    			<!-- This route is chosen if there is a log file specified -->
+    			<Route>
+			        <!-- File Appender -->
+			        <RollingFile name="${basePath}/${main:\-log}" 
+			        			fileName="${basePath}/${main:\-log}"
+			        			filePattern="${basePath}/${main:\-log}.%i"
+			        			append="false">
+			        	<!-- PatternLayout pattern="%d{dd MMM yyyy HH:mm:ss,SSSZ}[%t] %5p %c: %m%n" />  -->
+			        	<PatternLayout pattern="%d{ddMMMyyyy HH:mm:ss,SSS}| %5p: %m%n" />
+			            <Policies>
+ 							<SizeBasedTriggeringPolicy size="50000000" />
+						</Policies>
+						<DefaultRolloverStrategy max="10" />
+			        </RollingFile>
+    			</Route>
+    		</Routes>
+    	</Routing>
+    </Appenders>
+    <Loggers>
+		<Logger name="com.ibm.team.repository.common" level="OFF" />
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Remove all instances of System.out.println and replace with logging messages.  Synced a few debug messages that exist in the EWM repo.  All commands will now have access to a logger member that will put log messages into the log when the trace or debug is enabled.