### PR TITLE
changed from commons-lang  to commons-text

### DIFF
--- a/com.ibm.js.team.workitem.commandline/.classpath
+++ b/com.ibm.js.team.workitem.commandline/.classpath
@@ -9,10 +9,10 @@
 	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/PlainJavaApi"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/OpenCSV"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Commons-lang"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/SLF4J"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JunoAll"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Commons-text"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/EWMCommon"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JenaCore"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JunoAll"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/com.ibm.js.team.workitem.commandline/lib/ReadMe.txt
+++ b/com.ibm.js.team.workitem.commandline/lib/ReadMe.txt
@@ -12,10 +12,8 @@ Rename the jar file e.g. opencsv-3.7.jar to opencsv.jar
 1.a Copy the library file opencsv.jar into /com.ibm.js.team.workitem.commandline/lib to be able to run from Eclipse.
 1.b Place the library opencsv.jar into the folder lib in the WCL folder (see /com.ibm.js.team.workitem.commandline/ReadMe - HowToRelease.txt). 
 
-2. Download apache commons-lang from 
-https://commons.apache.org/proper/commons-lang/download_lang.cgi
-
-Version 3-3.1 works.
+2. Download apache commons-text from 
+https://commons.apache.org/proper/commons-text/download_text.cgi
 
 Rename the jar file e.g. commons-lang3-3.1.jar to commons-lang.jar
 The org.apache.commons.lang jar can also be found in the EWM server install.

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/FindEnumerationIdConflictsCommand.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/commands/FindEnumerationIdConflictsCommand.java
@@ -14,7 +14,7 @@ import java.net.URI;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 

--- a/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/ProcessAreaOslcHelper.java
+++ b/com.ibm.js.team.workitem.commandline/src/main/java/com/ibm/js/team/workitem/commandline/helper/ProcessAreaOslcHelper.java
@@ -20,7 +20,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.Logger;
 
 import org.w3c.dom.Document;


### PR DESCRIPTION
2. Download apache commons-text from 
https://commons.apache.org/proper/commons-text/download_text.cgi


org.apache.commons.lang.StringEscapeUtils is deprecated in more recent commons-lang library versions. Instead use org.apache.commons.text.StringEscapeUtils. Removed Commons-lang user library, added Commons-text user library.